### PR TITLE
Add worker auth, heartbeat pruning, and stream cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 Llamapool is a minimal worker pool that exposes an Ollama-compatible HTTP API. The
 `llamapool-server` binary accepts client requests and dispatches them to connected
-`llamapool-worker` processes over WebSocket.
+`llamapool-worker` processes over WebSocket. Workers authenticate using a shared
+bearer token provided via the `TOKEN` environment variable.
 
 ## Build
 
@@ -32,6 +33,12 @@ SERVER_URL=ws://localhost:8080/workers/connect TOKEN=secret OLLAMA_URL=http://12
 curl -N -X POST http://localhost:8080/api/generate \
   -H 'Content-Type: application/json' \
   -d '{"model":"llama3","prompt":"Hello","stream":true}'
+```
+
+The server also exposes a basic health check:
+
+```bash
+curl http://localhost:8080/healthz
 ```
 
 ## Testing

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -1,0 +1,26 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	chiMiddleware "github.com/go-chi/chi/v5/middleware"
+)
+
+func TestRequestIDMiddleware(t *testing.T) {
+	chain := middlewareChain()
+	var captured string
+	var h http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = chiMiddleware.GetReqID(r.Context())
+	})
+	for i := len(chain) - 1; i >= 0; i-- {
+		h = chain[i](h)
+	}
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	h.ServeHTTP(rr, req)
+	if captured == "" {
+		t.Fatalf("missing request id")
+	}
+}

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -3,6 +3,7 @@ package relay
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -32,5 +33,19 @@ func TestRelayGenerateStream(t *testing.T) {
 	lines := strings.Split(strings.TrimSpace(rr.Body.String()), "\n")
 	if len(lines) != 2 {
 		t.Fatalf("expected 2 lines, got %d", len(lines))
+	}
+}
+
+func TestRelayGenerateBusy(t *testing.T) {
+	reg := ctrl.NewRegistry()
+	worker := &ctrl.Worker{ID: "w1", Models: map[string]bool{"m": true}, Send: make(chan interface{}, 1), Jobs: make(map[string]chan interface{})}
+	worker.Send <- struct{}{}
+	reg.Add(worker)
+	sched := &ctrl.LeastBusyScheduler{Reg: reg}
+	req := GenerateRequest{Model: "m", Prompt: "hi", Stream: true}
+	rr := httptest.NewRecorder()
+	err := RelayGenerateStream(context.Background(), reg, sched, req, rr)
+	if !errors.Is(err, ErrWorkerBusy) {
+		t.Fatalf("expected busy error")
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -17,7 +17,10 @@ func New(reg *ctrl.Registry, sched ctrl.Scheduler, cfg config.ServerConfig) http
 	r := chi.NewRouter()
 	r.Mount("/api", api.NewRouter(reg, sched, cfg.RequestTimeout))
 	r.Handle(cfg.WSPath, ctrl.WSHandler(reg, cfg.WorkerToken))
-	r.Get("/healthz", func(w http.ResponseWriter, r *http.Request) { w.Write([]byte("ok")) })
+	r.Get("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"status":"ok"}`))
+	})
 	r.Handle("/metrics", promhttp.Handler())
 
 	go func() {

--- a/test/e2e_auth_test.go
+++ b/test/e2e_auth_test.go
@@ -1,0 +1,62 @@
+package test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"nhooyr.io/websocket"
+
+	"github.com/you/llamapool/internal/config"
+	"github.com/you/llamapool/internal/ctrl"
+	"github.com/you/llamapool/internal/server"
+)
+
+func TestWorkerAuth(t *testing.T) {
+	reg := ctrl.NewRegistry()
+	sched := &ctrl.LeastBusyScheduler{Reg: reg}
+	cfg := config.ServerConfig{WorkerToken: "secret", WSPath: "/workers/connect", RequestTimeout: 5 * time.Second}
+	handler := server.New(reg, sched, cfg)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	ctx := context.Background()
+	wsURL := strings.Replace(srv.URL, "http", "ws", 1) + "/workers/connect"
+
+	// bad token
+	_, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{HTTPHeader: http.Header{"Authorization": {"Bearer nope"}}})
+	if err == nil {
+		t.Fatalf("expected auth failure")
+	}
+	if len(reg.Models()) != 0 {
+		t.Fatalf("unexpected worker registered")
+	}
+
+	// good token
+	conn, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{HTTPHeader: http.Header{"Authorization": {"Bearer secret"}}})
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	regMsg := ctrl.RegisterMessage{Type: "register", WorkerID: "w1", Models: []string{"m"}, MaxConcurrency: 1}
+	b, _ := json.Marshal(regMsg)
+	conn.Write(ctx, websocket.MessageText, b)
+
+	// wait for registration
+	for i := 0; i < 50; i++ {
+		if len(reg.Models()) > 0 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/api/tags", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		t.Fatalf("tags: %v %d", err, resp.StatusCode)
+	}
+	resp.Body.Close()
+}

--- a/test/e2e_busy_test.go
+++ b/test/e2e_busy_test.go
@@ -1,0 +1,43 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/you/llamapool/internal/config"
+	"github.com/you/llamapool/internal/ctrl"
+	"github.com/you/llamapool/internal/relay"
+	"github.com/you/llamapool/internal/server"
+)
+
+func TestWorkerBusy(t *testing.T) {
+	reg := ctrl.NewRegistry()
+	worker := &ctrl.Worker{ID: "w1", Models: map[string]bool{"m": true}, Send: make(chan interface{}, 1), Jobs: make(map[string]chan interface{})}
+	worker.Send <- struct{}{}
+	reg.Add(worker)
+	sched := &ctrl.LeastBusyScheduler{Reg: reg}
+	cfg := config.ServerConfig{WorkerToken: "secret", WSPath: "/workers/connect", RequestTimeout: 5 * time.Second}
+	handler := server.New(reg, sched, cfg)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	req := relay.GenerateRequest{Model: "m", Prompt: "hi", Stream: true}
+	b, _ := json.Marshal(req)
+	resp, err := http.Post(srv.URL+"/api/generate", "application/json", bytes.NewReader(b))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", resp.StatusCode)
+	}
+	var v map[string]string
+	json.NewDecoder(resp.Body).Decode(&v)
+	if v["error"] != "worker_busy" {
+		t.Fatalf("unexpected error body: %v", v)
+	}
+}

--- a/test/e2e_cancel_test.go
+++ b/test/e2e_cancel_test.go
@@ -1,0 +1,96 @@
+package test
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"nhooyr.io/websocket"
+
+	"github.com/you/llamapool/internal/config"
+	"github.com/you/llamapool/internal/ctrl"
+	"github.com/you/llamapool/internal/relay"
+	"github.com/you/llamapool/internal/server"
+)
+
+func TestCancelPropagates(t *testing.T) {
+	reg := ctrl.NewRegistry()
+	sched := &ctrl.LeastBusyScheduler{Reg: reg}
+	cfg := config.ServerConfig{WorkerToken: "secret", WSPath: "/workers/connect", RequestTimeout: 5 * time.Second}
+	handler := server.New(reg, sched, cfg)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	ctx := context.Background()
+	wsURL := strings.Replace(srv.URL, "http", "ws", 1) + "/workers/connect"
+	cancelReceived := make(chan struct{})
+	go func() {
+		conn, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{HTTPHeader: http.Header{"Authorization": {"Bearer secret"}}})
+		if err != nil {
+			return
+		}
+		defer conn.Close(websocket.StatusNormalClosure, "")
+		regMsg := ctrl.RegisterMessage{Type: "register", WorkerID: "w1", Models: []string{"m"}, MaxConcurrency: 1}
+		b, _ := json.Marshal(regMsg)
+		conn.Write(ctx, websocket.MessageText, b)
+		for {
+			_, data, err := conn.Read(ctx)
+			if err != nil {
+				return
+			}
+			var env struct {
+				Type string `json:"type"`
+			}
+			json.Unmarshal(data, &env)
+			switch env.Type {
+			case "job_request":
+				var jr ctrl.JobRequestMessage
+				json.Unmarshal(data, &jr)
+				chunk := ctrl.JobChunkMessage{Type: "job_chunk", JobID: jr.JobID, Data: json.RawMessage(`{"response":"hi","done":false}`)}
+				bb, _ := json.Marshal(chunk)
+				conn.Write(ctx, websocket.MessageText, bb)
+			case "cancel_job":
+				close(cancelReceived)
+				return
+			}
+		}
+	}()
+
+	// wait for worker registration
+	for i := 0; i < 50; i++ {
+		if len(reg.Models()) > 0 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	req := relay.GenerateRequest{Model: "m", Prompt: "hi", Stream: true}
+	b, _ := json.Marshal(req)
+	cctx, cancel := context.WithCancel(context.Background())
+	httpReq, _ := http.NewRequestWithContext(cctx, http.MethodPost, srv.URL+"/api/generate", bytes.NewReader(b))
+	httpReq.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	scanner := bufio.NewScanner(resp.Body)
+	if !scanner.Scan() {
+		t.Fatalf("expected first line")
+	}
+	cancel()
+	if scanner.Scan() {
+		t.Fatalf("unexpected extra line after cancel")
+	}
+	resp.Body.Close()
+	select {
+	case <-cancelReceived:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("worker did not receive cancel")
+	}
+}

--- a/test/e2e_prune_test.go
+++ b/test/e2e_prune_test.go
@@ -1,0 +1,52 @@
+package test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"nhooyr.io/websocket"
+
+	"github.com/you/llamapool/internal/config"
+	"github.com/you/llamapool/internal/ctrl"
+	"github.com/you/llamapool/internal/server"
+)
+
+func TestHeartbeatPrune(t *testing.T) {
+	reg := ctrl.NewRegistry()
+	sched := &ctrl.LeastBusyScheduler{Reg: reg}
+	cfg := config.ServerConfig{WorkerToken: "secret", WSPath: "/workers/connect", RequestTimeout: 5 * time.Second}
+	handler := server.New(reg, sched, cfg)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	ctx := context.Background()
+	wsURL := strings.Replace(srv.URL, "http", "ws", 1) + "/workers/connect"
+	conn, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{HTTPHeader: http.Header{"Authorization": {"Bearer secret"}}})
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	regMsg := ctrl.RegisterMessage{Type: "register", WorkerID: "w1", Models: []string{"m"}, MaxConcurrency: 1}
+	b, _ := json.Marshal(regMsg)
+	conn.Write(ctx, websocket.MessageText, b)
+
+	// ensure registration
+	for i := 0; i < 50; i++ {
+		if len(reg.Models()) > 0 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// prune immediately
+	reg.PruneExpired(0)
+
+	if len(reg.Models()) != 0 {
+		t.Fatalf("expected models pruned")
+	}
+}

--- a/test/e2e_routes_test.go
+++ b/test/e2e_routes_test.go
@@ -1,0 +1,47 @@
+package test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/you/llamapool/internal/config"
+	"github.com/you/llamapool/internal/ctrl"
+	"github.com/you/llamapool/internal/server"
+)
+
+func TestRoutes(t *testing.T) {
+	reg := ctrl.NewRegistry()
+	sched := &ctrl.LeastBusyScheduler{Reg: reg}
+	cfg := config.ServerConfig{WorkerToken: "secret", WSPath: "/workers/connect", RequestTimeout: 5 * time.Second}
+	handler := server.New(reg, sched, cfg)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/tags")
+	if err != nil || resp.StatusCode != http.StatusOK {
+		t.Fatalf("/api/tags: %v %d", err, resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	resp, _ = http.Get(srv.URL + "/tags")
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404 for /tags")
+	}
+	resp.Body.Close()
+
+	resp, err = http.Get(srv.URL + "/healthz")
+	if err != nil || resp.StatusCode != http.StatusOK {
+		t.Fatalf("/healthz: %v %d", err, resp.StatusCode)
+	}
+	var v struct {
+		Status string `json:"status"`
+	}
+	json.NewDecoder(resp.Body).Decode(&v)
+	resp.Body.Close()
+	if v.Status != "ok" {
+		t.Fatalf("bad health body")
+	}
+}

--- a/test/e2e_server_worker_generate_test.go
+++ b/test/e2e_server_worker_generate_test.go
@@ -31,7 +31,7 @@ func TestE2EGenerateStream(t *testing.T) {
 	ctx := context.Background()
 	wsURL := strings.Replace(srv.URL, "http", "ws", 1) + "/workers/connect"
 	go func() {
-		conn, _, err := websocket.Dial(ctx, wsURL, nil)
+		conn, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{HTTPHeader: http.Header{"Authorization": {"Bearer secret"}}})
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
## Summary
- require bearer token for worker websocket connections and add Authorization header on worker dial
- prune stale workers on missed heartbeats and log evictions
- improve streaming generate: propagate client cancel, ensure final done, and return worker_busy errors in JSON
- expose JSON `/healthz` endpoint and add request/job/worker IDs to logs

## Testing
- `go test ./... -race -coverprofile=coverage.out`


------
https://chatgpt.com/codex/tasks/task_e_689a8e1c239c832cb9cc6366be71cf2f