### PR TITLE
Fix stream error handling and document model requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ curl -N -X POST http://localhost:8080/api/generate `
   -d '{ "model": "llama3", "prompt": "Hello", "stream": true }'
 ```
 
+Ensure that the requested `model` is installed on the connected worker's local
+Ollama instance. If the model is missing, the server responds with `no worker`.
+
 
 ## Testing
 

--- a/internal/api/generate.go
+++ b/internal/api/generate.go
@@ -24,9 +24,6 @@ func GenerateHandler(reg *ctrl.Registry, sched ctrl.Scheduler, timeout time.Dura
 		if req.Stream {
 			w.Header().Set("Content-Type", "application/json")
 			w.Header().Set("Cache-Control", "no-store")
-			if f, ok := w.(http.Flusher); ok {
-				f.Flush()
-			}
 			if err := relay.RelayGenerateStream(ctx, reg, sched, req, w); err != nil {
 				handleRelayErr(w, err)
 			}


### PR DESCRIPTION
## Summary
- avoid premature response flush when streaming and return proper errors
- document that requested model must exist on connected worker

## Testing
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689a9aaf79c4832c9bea5309e6020402