### PR TITLE
Add worker names and models API

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ go run .\cmd\llamapool-server
 On Linux:
 
 ```bash
-SERVER_URL=ws://localhost:8080/workers/connect TOKEN=secret OLLAMA_URL=http://127.0.0.1:11434 go run ./cmd/llamapool-worker
+SERVER_URL=ws://localhost:8080/workers/connect TOKEN=secret OLLAMA_URL=http://127.0.0.1:11434 WORKER_NAME=Alpha go run ./cmd/llamapool-worker
 ```
 
 On Windows (CMD)
@@ -76,6 +76,7 @@ On Windows (Powershell)
 $env:SERVER_URL = "ws://localhost:8080/workers/connect"
 $env:TOKEN = "secret"
 $env:OLLAMA_URL = "http://127.0.0.1:11434"
+$env:WORKER_NAME = "Alpha"
 go run .\cmd\llamapool-worker
 # or:
 .\bin\llamapool-worker.exe
@@ -137,6 +138,13 @@ The server also exposes a basic health check:
 
 ```bash
 curl http://localhost:8080/healthz
+```
+
+The server also exposes OpenAI-style model listing endpoints:
+
+```bash
+curl http://localhost:8080/v1/models
+curl http://localhost:8080/v1/models/llama3:8b
 ```
 
 ## Testing

--- a/internal/api/models.go
+++ b/internal/api/models.go
@@ -1,0 +1,55 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/you/llamapool/internal/ctrl"
+)
+
+// ListModelsHandler handles GET /v1/models.
+func ListModelsHandler(reg *ctrl.Registry) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		models := reg.AggregatedModels()
+		type item struct {
+			ID      string `json:"id"`
+			Object  string `json:"object"`
+			Created int64  `json:"created"`
+			OwnedBy string `json:"owned_by"`
+		}
+		var resp struct {
+			Object string `json:"object"`
+			Data   []item `json:"data"`
+		}
+		resp.Object = "list"
+		for _, m := range models {
+			resp.Data = append(resp.Data, item{ID: m.ID, Object: "model", Created: m.Created, OwnedBy: strings.Join(m.Owners, ",")})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}
+}
+
+// GetModelHandler handles GET /v1/models/{id}.
+func GetModelHandler(reg *ctrl.Registry) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		m, ok := reg.AggregatedModel(id)
+		w.Header().Set("Content-Type", "application/json")
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			json.NewEncoder(w).Encode(map[string]string{"error": "model_not_found"})
+			return
+		}
+		resp := struct {
+			ID      string `json:"id"`
+			Object  string `json:"object"`
+			Created int64  `json:"created"`
+			OwnedBy string `json:"owned_by"`
+		}{ID: m.ID, Object: "model", Created: m.Created, OwnedBy: strings.Join(m.Owners, ",")}
+		json.NewEncoder(w).Encode(resp)
+	}
+}

--- a/internal/config/worker.go
+++ b/internal/config/worker.go
@@ -2,7 +2,10 @@ package config
 
 import (
 	"flag"
+	"os"
 	"strconv"
+
+	"github.com/google/uuid"
 )
 
 // WorkerConfig holds configuration for the worker agent.
@@ -12,6 +15,7 @@ type WorkerConfig struct {
 	OllamaURL      string
 	MaxConcurrency int
 	WorkerID       string
+	WorkerName     string
 }
 
 func (c *WorkerConfig) BindFlags() {
@@ -26,9 +30,16 @@ func (c *WorkerConfig) BindFlags() {
 	}
 	c.WorkerID = getEnv("WORKER_ID", "")
 
+	host, err := os.Hostname()
+	if err != nil || host == "" {
+		host = "worker-" + uuid.NewString()[:8]
+	}
+	c.WorkerName = getEnv("WORKER_NAME", host)
+
 	flag.StringVar(&c.ServerURL, "server-url", c.ServerURL, "server websocket url")
 	flag.StringVar(&c.Token, "token", c.Token, "registration token")
 	flag.StringVar(&c.OllamaURL, "ollama-url", c.OllamaURL, "local Ollama URL")
 	flag.IntVar(&c.MaxConcurrency, "max-concurrency", c.MaxConcurrency, "max concurrent jobs")
 	flag.StringVar(&c.WorkerID, "worker-id", c.WorkerID, "worker identifier")
+	flag.StringVar(&c.WorkerName, "worker-name", c.WorkerName, "worker display name")
 }

--- a/internal/ctrl/messages.go
+++ b/internal/ctrl/messages.go
@@ -5,6 +5,7 @@ import "encoding/json"
 type RegisterMessage struct {
 	Type           string   `json:"type"`
 	WorkerID       string   `json:"worker_id"`
+	WorkerName     string   `json:"worker_name,omitempty"`
 	Token          string   `json:"token"`
 	Models         []string `json:"models"`
 	MaxConcurrency int      `json:"max_concurrency"`

--- a/internal/ctrl/models.go
+++ b/internal/ctrl/models.go
@@ -1,0 +1,53 @@
+package ctrl
+
+import (
+	"sort"
+)
+
+// ModelInfo represents an aggregated view of a model across workers.
+type ModelInfo struct {
+	ID      string
+	Created int64
+	Owners  []string
+}
+
+// AggregatedModels returns a list of models with ownership information.
+func (r *Registry) AggregatedModels() []ModelInfo {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	m := make(map[string]*ModelInfo)
+	for _, w := range r.workers {
+		for id := range w.Models {
+			info, ok := m[id]
+			if !ok {
+				info = &ModelInfo{ID: id, Created: r.modelFirstSeen[id]}
+				m[id] = info
+			}
+			info.Owners = append(info.Owners, w.Name)
+		}
+	}
+	var res []ModelInfo
+	for _, info := range m {
+		sort.Strings(info.Owners)
+		res = append(res, *info)
+	}
+	sort.Slice(res, func(i, j int) bool { return res[i].ID < res[j].ID })
+	return res
+}
+
+// AggregatedModel returns the aggregated info for a single model id.
+func (r *Registry) AggregatedModel(id string) (ModelInfo, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	var owners []string
+	for _, w := range r.workers {
+		if w.Models[id] {
+			owners = append(owners, w.Name)
+		}
+	}
+	if len(owners) == 0 {
+		return ModelInfo{}, false
+	}
+	sort.Strings(owners)
+	return ModelInfo{ID: id, Created: r.modelFirstSeen[id], Owners: owners}, true
+}

--- a/internal/ctrl/models_test.go
+++ b/internal/ctrl/models_test.go
@@ -1,0 +1,43 @@
+package ctrl
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAggregatedModels(t *testing.T) {
+	reg := NewRegistry()
+	reg.Add(&Worker{ID: "w1", Name: "Alpha", Models: map[string]bool{"llama3:8b": true, "mistral:7b": true}})
+	reg.Add(&Worker{ID: "w2", Name: "Beta", Models: map[string]bool{"llama3:8b": true, "qwen2.5:14b": true}})
+
+	list := reg.AggregatedModels()
+	if len(list) != 3 {
+		t.Fatalf("expected 3 models, got %d", len(list))
+	}
+	var found bool
+	for _, m := range list {
+		if m.ID == "llama3:8b" {
+			found = true
+			if owners := strings.Join(m.Owners, ","); owners != "Alpha,Beta" {
+				t.Fatalf("owners wrong: %s", owners)
+			}
+			if m.Created <= 0 {
+				t.Fatalf("created not set")
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("llama3:8b not found")
+	}
+
+	m, ok := reg.AggregatedModel("llama3:8b")
+	if !ok {
+		t.Fatalf("model not found")
+	}
+	if owners := strings.Join(m.Owners, ","); owners != "Alpha,Beta" {
+		t.Fatalf("owners wrong: %s", owners)
+	}
+	if m.Created <= 0 {
+		t.Fatalf("created not set")
+	}
+}

--- a/internal/ctrl/ws_workername_test.go
+++ b/internal/ctrl/ws_workername_test.go
@@ -1,0 +1,73 @@
+package ctrl
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"nhooyr.io/websocket"
+)
+
+func TestRegisterStoresWorkerName(t *testing.T) {
+	reg := NewRegistry()
+	srv := httptest.NewServer(WSHandler(reg, ""))
+	defer srv.Close()
+
+	ctx := context.Background()
+	wsURL := strings.Replace(srv.URL, "http", "ws", 1)
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	rm := RegisterMessage{Type: "register", WorkerID: "w1abcdef", WorkerName: "Alpha", Models: []string{"m"}, MaxConcurrency: 1}
+	b, _ := json.Marshal(rm)
+	conn.Write(ctx, websocket.MessageText, b)
+	// wait for registration
+	for i := 0; i < 50; i++ {
+		reg.mu.RLock()
+		w, ok := reg.workers["w1abcdef"]
+		reg.mu.RUnlock()
+		if ok {
+			if w.Name != "Alpha" {
+				t.Fatalf("expected name Alpha, got %s", w.Name)
+			}
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestRegisterFallbackName(t *testing.T) {
+	reg := NewRegistry()
+	srv := httptest.NewServer(WSHandler(reg, ""))
+	defer srv.Close()
+
+	ctx := context.Background()
+	wsURL := strings.Replace(srv.URL, "http", "ws", 1)
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	rm := RegisterMessage{Type: "register", WorkerID: "w123456789", Models: []string{"m"}, MaxConcurrency: 1}
+	b, _ := json.Marshal(rm)
+	conn.Write(ctx, websocket.MessageText, b)
+	var name string
+	for i := 0; i < 50; i++ {
+		reg.mu.RLock()
+		w, ok := reg.workers["w123456789"]
+		reg.mu.RUnlock()
+		if ok {
+			name = w.Name
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if name == "" || name != "w1234567" {
+		t.Fatalf("unexpected fallback name %q", name)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -16,6 +16,10 @@ import (
 func New(reg *ctrl.Registry, sched ctrl.Scheduler, cfg config.ServerConfig) http.Handler {
 	r := chi.NewRouter()
 	r.Mount("/api", api.NewRouter(reg, sched, cfg.RequestTimeout))
+	r.Route("/v1", func(r chi.Router) {
+		r.Get("/models", api.ListModelsHandler(reg))
+		r.Get("/models/{id}", api.GetModelHandler(reg))
+	})
 	r.Handle(cfg.WSPath, ctrl.WSHandler(reg, cfg.WorkerToken))
 	r.Get("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -44,7 +44,7 @@ func Run(ctx context.Context, cfg config.WorkerConfig) error {
 		}
 	}()
 
-	regMsg := ctrl.RegisterMessage{Type: "register", WorkerID: cfg.WorkerID, Token: cfg.Token, Models: models, MaxConcurrency: cfg.MaxConcurrency}
+	regMsg := ctrl.RegisterMessage{Type: "register", WorkerID: cfg.WorkerID, WorkerName: cfg.WorkerName, Token: cfg.Token, Models: models, MaxConcurrency: cfg.MaxConcurrency}
 	b, _ := json.Marshal(regMsg)
 	sendCh <- b
 

--- a/test/e2e_models_api_test.go
+++ b/test/e2e_models_api_test.go
@@ -1,0 +1,135 @@
+package test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"nhooyr.io/websocket"
+
+	"github.com/you/llamapool/internal/config"
+	"github.com/you/llamapool/internal/ctrl"
+	"github.com/you/llamapool/internal/server"
+)
+
+func TestModelsAPI(t *testing.T) {
+	reg := ctrl.NewRegistry()
+	sched := &ctrl.LeastBusyScheduler{Reg: reg}
+	cfg := config.ServerConfig{WSPath: "/workers/connect", RequestTimeout: 5 * time.Second}
+	handler := server.New(reg, sched, cfg)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	ctx := context.Background()
+	wsURL := strings.Replace(srv.URL, "http", "ws", 1) + "/workers/connect"
+
+	// Worker Alpha
+	connA, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial alpha: %v", err)
+	}
+	rmA := ctrl.RegisterMessage{Type: "register", WorkerID: "wA", WorkerName: "Alpha", Models: []string{"llama3:8b", "mistral:7b"}, MaxConcurrency: 1}
+	b, _ := json.Marshal(rmA)
+	connA.Write(ctx, websocket.MessageText, b)
+
+	// Worker Beta
+	connB, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial beta: %v", err)
+	}
+	rmB := ctrl.RegisterMessage{Type: "register", WorkerID: "wB", WorkerName: "Beta", Models: []string{"llama3:8b", "qwen2.5:14b"}, MaxConcurrency: 1}
+	b, _ = json.Marshal(rmB)
+	connB.Write(ctx, websocket.MessageText, b)
+
+	// wait for registration
+	for i := 0; i < 50; i++ {
+		resp, err := http.Get(srv.URL + "/v1/models")
+		if err == nil {
+			var lr struct {
+				Data []struct {
+					ID      string `json:"id"`
+					OwnedBy string `json:"owned_by"`
+				} `json:"data"`
+			}
+			json.NewDecoder(resp.Body).Decode(&lr)
+			resp.Body.Close()
+			if len(lr.Data) == 3 {
+				break
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	resp, err := http.Get(srv.URL + "/v1/models")
+	if err != nil {
+		t.Fatalf("list models: %v", err)
+	}
+	var list struct {
+		Data []struct {
+			ID      string `json:"id"`
+			OwnedBy string `json:"owned_by"`
+		} `json:"data"`
+	}
+	json.NewDecoder(resp.Body).Decode(&list)
+	resp.Body.Close()
+	if len(list.Data) != 3 {
+		t.Fatalf("expected 3 models, got %d", len(list.Data))
+	}
+	for _, m := range list.Data {
+		if m.ID == "llama3:8b" && m.OwnedBy != "Alpha,Beta" {
+			t.Fatalf("owned_by wrong: %s", m.OwnedBy)
+		}
+	}
+
+	resp, err = http.Get(srv.URL + "/v1/models/llama3:8b")
+	if err != nil || resp.StatusCode != http.StatusOK {
+		t.Fatalf("get model: %v %d", err, resp.StatusCode)
+	}
+	resp.Body.Close()
+	resp, err = http.Get(srv.URL + "/v1/models/doesnotexist")
+	if err != nil || resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("missing model: %v %d", err, resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	connB.Close(websocket.StatusNormalClosure, "")
+	// wait for deregistration
+	for i := 0; i < 50; i++ {
+		resp, err := http.Get(srv.URL + "/v1/models")
+		if err == nil {
+			var lr struct {
+				Data []struct {
+					ID      string `json:"id"`
+					OwnedBy string `json:"owned_by"`
+				} `json:"data"`
+			}
+			json.NewDecoder(resp.Body).Decode(&lr)
+			resp.Body.Close()
+			if len(lr.Data) == 2 {
+				break
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	resp, err = http.Get(srv.URL + "/v1/models")
+	if err != nil {
+		t.Fatalf("list after disconnect: %v", err)
+	}
+	json.NewDecoder(resp.Body).Decode(&list)
+	resp.Body.Close()
+	for _, m := range list.Data {
+		if m.ID == "llama3:8b" && m.OwnedBy != "Alpha" {
+			t.Fatalf("owned_by after disconnect: %s", m.OwnedBy)
+		}
+		if m.ID == "qwen2.5:14b" {
+			t.Fatalf("beta model still listed")
+		}
+	}
+
+	connA.Close(websocket.StatusNormalClosure, "")
+}


### PR DESCRIPTION
## Summary
- allow workers to report a configurable `worker_name`
- expose aggregated model info via `/v1/models` and `/v1/models/{id}`
- track worker names and first-seen timestamps in registry

## Testing
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689ac505a7b0832ca9aae79db48edecd