### PR TITLE
feat: add API and worker key auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 Llamapool is a minimal worker pool that exposes an Ollama-compatible HTTP API. The
 `llamapool-server` binary accepts client requests and dispatches them to connected
 `llamapool-worker` processes over WebSocket. Workers authenticate using a shared
-bearer token provided via the `TOKEN` environment variable.
+key provided via the `WORKER_KEY` environment variable. Client HTTP requests can
+be protected with an `API_KEY` passed in the `Authorization` header.
 
 ## Build
 
@@ -28,14 +29,15 @@ go build -o .\bin\llamapool-worker.exe .\cmd\llamapool-worker
 On Linux:
 
 ```bash
-PORT=8080 WORKER_TOKEN=secret go run ./cmd/llamapool-server
+PORT=8080 WORKER_KEY=secret API_KEY=test123 go run ./cmd/llamapool-server
 ```
 
 On Windows (CMD)
 
 ```
 set PORT=8080
-set WORKER_TOKEN=secret
+set WORKER_KEY=secret
+set API_KEY=test123
 go run .\cmd\llamapool-server
 REM or if you built:
 .\bin\llamapool-server.exe
@@ -44,7 +46,7 @@ REM or if you built:
 On Windows (Powershell)
 
 ```
-$env:PORT = "8080"; $env:WORKER_TOKEN = "secret"
+$env:PORT = "8080"; $env:WORKER_KEY = "secret"; $env:API_KEY = "test123"
 go run .\cmd\llamapool-server
 # or if you built:
 .\bin\llamapool-server.exe
@@ -56,14 +58,14 @@ go run .\cmd\llamapool-server
 On Linux:
 
 ```bash
-SERVER_URL=ws://localhost:8080/workers/connect TOKEN=secret OLLAMA_URL=http://127.0.0.1:11434 WORKER_NAME=Alpha go run ./cmd/llamapool-worker
+SERVER_URL=ws://localhost:8080/workers/connect WORKER_KEY=secret OLLAMA_URL=http://127.0.0.1:11434 WORKER_NAME=Alpha go run ./cmd/llamapool-worker
 ```
 
 On Windows (CMD)
 
 ```
 set SERVER_URL=ws://localhost:8080/workers/connect
-set TOKEN=secret
+set WORKER_KEY=secret
 set OLLAMA_URL=http://127.0.0.1:11434
 go run .\cmd\llamapool-worker
 REM or if you built:
@@ -74,7 +76,7 @@ On Windows (Powershell)
 
 ```
 $env:SERVER_URL = "ws://localhost:8080/workers/connect"
-$env:TOKEN = "secret"
+$env:WORKER_KEY = "secret"
 $env:OLLAMA_URL = "http://127.0.0.1:11434"
 $env:WORKER_NAME = "Alpha"
 go run .\cmd\llamapool-worker
@@ -94,7 +96,7 @@ Pre-built images are available:
 ### Server
 
 ```bash
-docker run --rm -p 8080:8080 -e WORKER_TOKEN=secret \
+docker run --rm -p 8080:8080 -e WORKER_KEY=secret -e API_KEY=test123 \
   ghcr.io/gaspardpetit/llamapool-server:main
 ```
 
@@ -103,7 +105,7 @@ docker run --rm -p 8080:8080 -e WORKER_TOKEN=secret \
 ```bash
 docker run --rm \
   -e SERVER_URL=ws://localhost:8080/workers/connect \
-  -e TOKEN=secret \
+  -e WORKER_KEY=secret \
   -e OLLAMA_URL=http://host.docker.internal:11434 \
   ghcr.io/gaspardpetit/llamapool-client:main
 ```
@@ -118,6 +120,7 @@ On Linux:
 ```bash
 curl -N -X POST http://localhost:8080/api/generate \
   -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer test123' \
   -d '{"model":"llama3","prompt":"Hello","stream":true}'
 ```
 
@@ -126,6 +129,7 @@ On Windows (CMD):
 ```
 curl -N -X POST "http://localhost:8080/api/generate" ^
   -H "Content-Type: application/json" ^
+  -H "Authorization: Bearer test123" ^
   -d "{ \"model\": \"llama3\", \"prompt\": \"Hello\", \"stream\": true }"
 ```
 
@@ -134,6 +138,7 @@ On Windows (Powershell):
 ```
 curl -N -X POST http://localhost:8080/api/generate `
   -H "Content-Type: application/json" `
+  -H "Authorization: Bearer test123" `
   -d '{ "model": "llama3", "prompt": "Hello", "stream": true }'
 ```
 
@@ -146,8 +151,8 @@ curl http://localhost:8080/healthz
 The server also exposes OpenAI-style model listing endpoints:
 
 ```bash
-curl http://localhost:8080/v1/models
-curl http://localhost:8080/v1/models/llama3:8b
+curl -H "Authorization: Bearer test123" http://localhost:8080/v1/models
+curl -H "Authorization: Bearer test123" http://localhost:8080/v1/models/llama3:8b
 ```
 
 ## Testing

--- a/cmd/llamapool-server/main.go
+++ b/cmd/llamapool-server/main.go
@@ -32,6 +32,12 @@ func main() {
 		srv.Shutdown(context.Background())
 	}()
 
+	if cfg.APIKey != "" {
+		logx.Log.Info().Msg("API key auth enabled")
+	}
+	if cfg.WorkerKey != "" {
+		logx.Log.Info().Msg("Worker key required")
+	}
 	logx.Log.Info().Int("port", cfg.Port).Msg("server starting")
 	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		logx.Log.Fatal().Err(err).Msg("server error")

--- a/cmd/llamapool-worker/main.go
+++ b/cmd/llamapool-worker/main.go
@@ -20,6 +20,12 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
+	log := logx.Log.Info().Str("worker_name", cfg.WorkerName)
+	if cfg.WorkerKey != "" {
+		log = log.Bool("auth", true)
+	}
+	log.Msg("worker starting")
+
 	if err := worker.Run(ctx, cfg); err != nil {
 		logx.Log.Fatal().Err(err).Msg("worker exited")
 	}

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -9,7 +9,8 @@ import (
 // ServerConfig holds configuration for the llamapool server.
 type ServerConfig struct {
 	Port           int
-	WorkerToken    string
+	APIKey         string
+	WorkerKey      string
 	WSPath         string
 	RequestTimeout time.Duration
 }
@@ -19,13 +20,15 @@ type ServerConfig struct {
 func (c *ServerConfig) BindFlags() {
 	port, _ := strconv.Atoi(getEnv("PORT", "8080"))
 	c.Port = port
-	c.WorkerToken = getEnv("WORKER_TOKEN", "")
+	c.APIKey = getEnv("API_KEY", "")
+	c.WorkerKey = getEnv("WORKER_KEY", "")
 	c.WSPath = getEnv("WS_PATH", "/workers/connect")
 	rt, _ := time.ParseDuration(getEnv("REQUEST_TIMEOUT", "60s"))
 	c.RequestTimeout = rt
 
 	flag.IntVar(&c.Port, "port", c.Port, "HTTP listen port")
-	flag.StringVar(&c.WorkerToken, "worker-token", c.WorkerToken, "worker shared token")
+	flag.StringVar(&c.APIKey, "api-key", c.APIKey, "client API key")
+	flag.StringVar(&c.WorkerKey, "worker-key", c.WorkerKey, "worker shared key")
 	flag.StringVar(&c.WSPath, "ws-path", c.WSPath, "websocket path")
 	flag.DurationVar(&c.RequestTimeout, "request-timeout", c.RequestTimeout, "request timeout")
 }

--- a/internal/config/worker.go
+++ b/internal/config/worker.go
@@ -11,7 +11,7 @@ import (
 // WorkerConfig holds configuration for the worker agent.
 type WorkerConfig struct {
 	ServerURL      string
-	Token          string
+	WorkerKey      string
 	OllamaURL      string
 	MaxConcurrency int
 	WorkerID       string
@@ -20,7 +20,7 @@ type WorkerConfig struct {
 
 func (c *WorkerConfig) BindFlags() {
 	c.ServerURL = getEnv("SERVER_URL", "ws://localhost:8080/workers/connect")
-	c.Token = getEnv("TOKEN", "")
+	c.WorkerKey = getEnv("WORKER_KEY", "")
 	c.OllamaURL = getEnv("OLLAMA_URL", "http://127.0.0.1:11434")
 	mc := getEnv("MAX_CONCURRENCY", "2")
 	if v, err := strconv.Atoi(mc); err == nil {
@@ -37,7 +37,7 @@ func (c *WorkerConfig) BindFlags() {
 	c.WorkerName = getEnv("WORKER_NAME", host)
 
 	flag.StringVar(&c.ServerURL, "server-url", c.ServerURL, "server websocket url")
-	flag.StringVar(&c.Token, "token", c.Token, "registration token")
+	flag.StringVar(&c.WorkerKey, "worker-key", c.WorkerKey, "worker auth key")
 	flag.StringVar(&c.OllamaURL, "ollama-url", c.OllamaURL, "local Ollama URL")
 	flag.IntVar(&c.MaxConcurrency, "max-concurrency", c.MaxConcurrency, "max concurrent jobs")
 	flag.StringVar(&c.WorkerID, "worker-id", c.WorkerID, "worker identifier")

--- a/internal/ctrl/messages.go
+++ b/internal/ctrl/messages.go
@@ -6,7 +6,8 @@ type RegisterMessage struct {
 	Type           string   `json:"type"`
 	WorkerID       string   `json:"worker_id"`
 	WorkerName     string   `json:"worker_name,omitempty"`
-	Token          string   `json:"token"`
+	WorkerKey      string   `json:"worker_key"`
+	Token          string   `json:"token,omitempty"`
 	Models         []string `json:"models"`
 	MaxConcurrency int      `json:"max_concurrency"`
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -15,12 +15,20 @@ import (
 // New constructs the HTTP handler for the server.
 func New(reg *ctrl.Registry, sched ctrl.Scheduler, cfg config.ServerConfig) http.Handler {
 	r := chi.NewRouter()
-	r.Mount("/api", api.NewRouter(reg, sched, cfg.RequestTimeout))
+	r.Route("/api", func(r chi.Router) {
+		if cfg.APIKey != "" {
+			r.Use(api.APIKeyMiddleware(cfg.APIKey))
+		}
+		r.Mount("/", api.NewRouter(reg, sched, cfg.RequestTimeout))
+	})
 	r.Route("/v1", func(r chi.Router) {
+		if cfg.APIKey != "" {
+			r.Use(api.APIKeyMiddleware(cfg.APIKey))
+		}
 		r.Get("/models", api.ListModelsHandler(reg))
 		r.Get("/models/{id}", api.GetModelHandler(reg))
 	})
-	r.Handle(cfg.WSPath, ctrl.WSHandler(reg, cfg.WorkerToken))
+	r.Handle(cfg.WSPath, ctrl.WSHandler(reg, cfg.WorkerKey))
 	r.Get("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte(`{"status":"ok"}`))

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -3,7 +3,6 @@ package worker
 import (
 	"context"
 	"encoding/json"
-	"net/http"
 	"sync"
 	"time"
 
@@ -27,9 +26,7 @@ func Run(ctx context.Context, cfg config.WorkerConfig) error {
 	if err != nil {
 		return err
 	}
-	ws, _, err := websocket.Dial(ctx, cfg.ServerURL, &websocket.DialOptions{HTTPHeader: http.Header{
-		"Authorization": {"Bearer " + cfg.Token},
-	}})
+	ws, _, err := websocket.Dial(ctx, cfg.ServerURL, nil)
 	if err != nil {
 		return err
 	}
@@ -44,7 +41,7 @@ func Run(ctx context.Context, cfg config.WorkerConfig) error {
 		}
 	}()
 
-	regMsg := ctrl.RegisterMessage{Type: "register", WorkerID: cfg.WorkerID, WorkerName: cfg.WorkerName, Token: cfg.Token, Models: models, MaxConcurrency: cfg.MaxConcurrency}
+	regMsg := ctrl.RegisterMessage{Type: "register", WorkerID: cfg.WorkerID, WorkerName: cfg.WorkerName, WorkerKey: cfg.WorkerKey, Models: models, MaxConcurrency: cfg.MaxConcurrency}
 	b, _ := json.Marshal(regMsg)
 	sendCh <- b
 

--- a/test/e2e_api_key_test.go
+++ b/test/e2e_api_key_test.go
@@ -1,0 +1,41 @@
+package test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/you/llamapool/internal/config"
+	"github.com/you/llamapool/internal/ctrl"
+	"github.com/you/llamapool/internal/server"
+)
+
+func TestAPIKeyEnforcement(t *testing.T) {
+	reg := ctrl.NewRegistry()
+	sched := &ctrl.LeastBusyScheduler{Reg: reg}
+	cfg := config.ServerConfig{APIKey: "test123", WSPath: "/workers/connect", RequestTimeout: 5 * time.Second}
+	handler := server.New(reg, sched, cfg)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/v1/models")
+	if err != nil {
+		t.Fatalf("get without key: %v", err)
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/v1/models", nil)
+	req.Header.Set("Authorization", "Bearer test123")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("get with key: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	resp.Body.Close()
+}

--- a/test/e2e_busy_test.go
+++ b/test/e2e_busy_test.go
@@ -20,7 +20,7 @@ func TestWorkerBusy(t *testing.T) {
 	worker.Send <- struct{}{}
 	reg.Add(worker)
 	sched := &ctrl.LeastBusyScheduler{Reg: reg}
-	cfg := config.ServerConfig{WorkerToken: "secret", WSPath: "/workers/connect", RequestTimeout: 5 * time.Second}
+	cfg := config.ServerConfig{WorkerKey: "secret", WSPath: "/workers/connect", RequestTimeout: 5 * time.Second}
 	handler := server.New(reg, sched, cfg)
 	srv := httptest.NewServer(handler)
 	defer srv.Close()

--- a/test/e2e_cancel_test.go
+++ b/test/e2e_cancel_test.go
@@ -22,7 +22,7 @@ import (
 func TestCancelPropagates(t *testing.T) {
 	reg := ctrl.NewRegistry()
 	sched := &ctrl.LeastBusyScheduler{Reg: reg}
-	cfg := config.ServerConfig{WorkerToken: "secret", WSPath: "/workers/connect", RequestTimeout: 5 * time.Second}
+	cfg := config.ServerConfig{WorkerKey: "secret", WSPath: "/workers/connect", RequestTimeout: 5 * time.Second}
 	handler := server.New(reg, sched, cfg)
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
@@ -31,12 +31,12 @@ func TestCancelPropagates(t *testing.T) {
 	wsURL := strings.Replace(srv.URL, "http", "ws", 1) + "/workers/connect"
 	cancelReceived := make(chan struct{})
 	go func() {
-		conn, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{HTTPHeader: http.Header{"Authorization": {"Bearer secret"}}})
+		conn, _, err := websocket.Dial(ctx, wsURL, nil)
 		if err != nil {
 			return
 		}
 		defer conn.Close(websocket.StatusNormalClosure, "")
-		regMsg := ctrl.RegisterMessage{Type: "register", WorkerID: "w1", Models: []string{"m"}, MaxConcurrency: 1}
+		regMsg := ctrl.RegisterMessage{Type: "register", WorkerID: "w1", WorkerKey: "secret", Models: []string{"m"}, MaxConcurrency: 1}
 		b, _ := json.Marshal(regMsg)
 		conn.Write(ctx, websocket.MessageText, b)
 		for {

--- a/test/e2e_routes_test.go
+++ b/test/e2e_routes_test.go
@@ -15,7 +15,7 @@ import (
 func TestRoutes(t *testing.T) {
 	reg := ctrl.NewRegistry()
 	sched := &ctrl.LeastBusyScheduler{Reg: reg}
-	cfg := config.ServerConfig{WorkerToken: "secret", WSPath: "/workers/connect", RequestTimeout: 5 * time.Second}
+	cfg := config.ServerConfig{WorkerKey: "secret", WSPath: "/workers/connect", RequestTimeout: 5 * time.Second}
 	handler := server.New(reg, sched, cfg)
 	srv := httptest.NewServer(handler)
 	defer srv.Close()

--- a/test/e2e_server_worker_generate_test.go
+++ b/test/e2e_server_worker_generate_test.go
@@ -22,7 +22,7 @@ import (
 func TestE2EGenerateStream(t *testing.T) {
 	reg := ctrl.NewRegistry()
 	sched := &ctrl.LeastBusyScheduler{Reg: reg}
-	cfg := config.ServerConfig{WorkerToken: "secret", WSPath: "/workers/connect", RequestTimeout: 5 * time.Second}
+	cfg := config.ServerConfig{WorkerKey: "secret", WSPath: "/workers/connect", RequestTimeout: 5 * time.Second}
 	handler := server.New(reg, sched, cfg)
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
@@ -31,12 +31,12 @@ func TestE2EGenerateStream(t *testing.T) {
 	ctx := context.Background()
 	wsURL := strings.Replace(srv.URL, "http", "ws", 1) + "/workers/connect"
 	go func() {
-		conn, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{HTTPHeader: http.Header{"Authorization": {"Bearer secret"}}})
+		conn, _, err := websocket.Dial(ctx, wsURL, nil)
 		if err != nil {
 			return
 		}
 		defer conn.Close(websocket.StatusNormalClosure, "")
-		regMsg := ctrl.RegisterMessage{Type: "register", WorkerID: "w1", Token: "secret", Models: []string{"llama3"}, MaxConcurrency: 2}
+		regMsg := ctrl.RegisterMessage{Type: "register", WorkerID: "w1", WorkerKey: "secret", Models: []string{"llama3"}, MaxConcurrency: 2}
 		b, _ := json.Marshal(regMsg)
 		conn.Write(ctx, websocket.MessageText, b)
 		for {


### PR DESCRIPTION
## Summary
- enforce optional API key on HTTP client routes
- rename worker TOKEN to WORKER_KEY in config and websocket protocol
- document new API/worker keys and add tests for auth paths

## Testing
- `make build`
- `make test`
- `go test ./... -race`


------
https://chatgpt.com/codex/tasks/task_e_689ad1181ee8832c9d70f4ba879631e6