### PR TITLE
Move completion endpoints under v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Ollama instance. If the model is missing, the server responds with `no worker`.
 On Linux:
 
 ```bash
-curl -N -X POST http://localhost:8080/api/generate \
+curl -N -X POST http://localhost:8080/v1/generate \
   -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer test123' \
   -d '{"model":"llama3","prompt":"Hello","stream":true}'
@@ -127,7 +127,7 @@ curl -N -X POST http://localhost:8080/api/generate \
 On Windows (CMD):
 
 ```
-curl -N -X POST "http://localhost:8080/api/generate" ^
+curl -N -X POST "http://localhost:8080/v1/generate" ^
   -H "Content-Type: application/json" ^
   -H "Authorization: Bearer test123" ^
   -d "{ \"model\": \"llama3\", \"prompt\": \"Hello\", \"stream\": true }"
@@ -136,7 +136,7 @@ curl -N -X POST "http://localhost:8080/api/generate" ^
 On Windows (Powershell):
 
 ```
-curl -N -X POST http://localhost:8080/api/generate `
+curl -N -X POST http://localhost:8080/v1/generate `
   -H "Content-Type: application/json" `
   -H "Authorization: Bearer test123" `
   -d '{ "model": "llama3", "prompt": "Hello", "stream": true }'

--- a/internal/api/generate.go
+++ b/internal/api/generate.go
@@ -11,7 +11,7 @@ import (
 	"github.com/you/llamapool/internal/relay"
 )
 
-// GenerateHandler handles POST /api/generate.
+// GenerateHandler handles POST /v1/generate.
 func GenerateHandler(reg *ctrl.Registry, sched ctrl.Scheduler, timeout time.Duration) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var req relay.GenerateRequest

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -8,7 +8,7 @@ import (
 	"github.com/you/llamapool/internal/ctrl"
 )
 
-// NewRouter builds the API router.
+// NewRouter builds the v1 API router.
 func NewRouter(reg *ctrl.Registry, sched ctrl.Scheduler, timeout time.Duration) chi.Router {
 	r := chi.NewRouter()
 	for _, m := range middlewareChain() {
@@ -16,5 +16,7 @@ func NewRouter(reg *ctrl.Registry, sched ctrl.Scheduler, timeout time.Duration) 
 	}
 	r.Post("/generate", GenerateHandler(reg, sched, timeout))
 	r.Get("/tags", TagsHandler(reg))
+	r.Get("/models", ListModelsHandler(reg))
+	r.Get("/models/{id}", GetModelHandler(reg))
 	return r
 }

--- a/internal/api/tags.go
+++ b/internal/api/tags.go
@@ -7,7 +7,7 @@ import (
 	"github.com/you/llamapool/internal/ctrl"
 )
 
-// TagsHandler handles GET /api/tags.
+// TagsHandler handles GET /v1/tags.
 func TagsHandler(reg *ctrl.Registry) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		models := reg.Models()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -15,18 +15,11 @@ import (
 // New constructs the HTTP handler for the server.
 func New(reg *ctrl.Registry, sched ctrl.Scheduler, cfg config.ServerConfig) http.Handler {
 	r := chi.NewRouter()
-	r.Route("/api", func(r chi.Router) {
-		if cfg.APIKey != "" {
-			r.Use(api.APIKeyMiddleware(cfg.APIKey))
-		}
-		r.Mount("/", api.NewRouter(reg, sched, cfg.RequestTimeout))
-	})
 	r.Route("/v1", func(r chi.Router) {
 		if cfg.APIKey != "" {
 			r.Use(api.APIKeyMiddleware(cfg.APIKey))
 		}
-		r.Get("/models", api.ListModelsHandler(reg))
-		r.Get("/models/{id}", api.GetModelHandler(reg))
+		r.Mount("/", api.NewRouter(reg, sched, cfg.RequestTimeout))
 	})
 	r.Handle(cfg.WSPath, ctrl.WSHandler(reg, cfg.WorkerKey))
 	r.Get("/healthz", func(w http.ResponseWriter, r *http.Request) {

--- a/test/e2e_auth_test.go
+++ b/test/e2e_auth_test.go
@@ -61,7 +61,7 @@ func TestWorkerAuth(t *testing.T) {
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/api/tags", nil)
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/v1/tags", nil)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil || resp.StatusCode != http.StatusOK {
 		t.Fatalf("tags: %v %d", err, resp.StatusCode)

--- a/test/e2e_busy_test.go
+++ b/test/e2e_busy_test.go
@@ -27,7 +27,7 @@ func TestWorkerBusy(t *testing.T) {
 
 	req := relay.GenerateRequest{Model: "m", Prompt: "hi", Stream: true}
 	b, _ := json.Marshal(req)
-	resp, err := http.Post(srv.URL+"/api/generate", "application/json", bytes.NewReader(b))
+	resp, err := http.Post(srv.URL+"/v1/generate", "application/json", bytes.NewReader(b))
 	if err != nil {
 		t.Fatalf("post: %v", err)
 	}

--- a/test/e2e_cancel_test.go
+++ b/test/e2e_cancel_test.go
@@ -73,7 +73,7 @@ func TestCancelPropagates(t *testing.T) {
 	req := relay.GenerateRequest{Model: "m", Prompt: "hi", Stream: true}
 	b, _ := json.Marshal(req)
 	cctx, cancel := context.WithCancel(context.Background())
-	httpReq, _ := http.NewRequestWithContext(cctx, http.MethodPost, srv.URL+"/api/generate", bytes.NewReader(b))
+	httpReq, _ := http.NewRequestWithContext(cctx, http.MethodPost, srv.URL+"/v1/generate", bytes.NewReader(b))
 	httpReq.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(httpReq)
 	if err != nil {

--- a/test/e2e_routes_test.go
+++ b/test/e2e_routes_test.go
@@ -20,9 +20,9 @@ func TestRoutes(t *testing.T) {
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
-	resp, err := http.Get(srv.URL + "/api/tags")
+	resp, err := http.Get(srv.URL + "/v1/tags")
 	if err != nil || resp.StatusCode != http.StatusOK {
-		t.Fatalf("/api/tags: %v %d", err, resp.StatusCode)
+		t.Fatalf("/v1/tags: %v %d", err, resp.StatusCode)
 	}
 	resp.Body.Close()
 

--- a/test/e2e_server_worker_generate_test.go
+++ b/test/e2e_server_worker_generate_test.go
@@ -63,7 +63,7 @@ func TestE2EGenerateStream(t *testing.T) {
 
 	// Wait for worker to register
 	for i := 0; i < 20; i++ {
-		resp, err := http.Get(srv.URL + "/api/tags")
+		resp, err := http.Get(srv.URL + "/v1/tags")
 		if err == nil {
 			var tr struct {
 				Models []struct {
@@ -82,7 +82,7 @@ func TestE2EGenerateStream(t *testing.T) {
 	// Call generate
 	req := relay.GenerateRequest{Model: "llama3", Prompt: "hi", Stream: true}
 	b, _ := json.Marshal(req)
-	resp, err := http.Post(srv.URL+"/api/generate", "application/json", bytes.NewReader(b))
+	resp, err := http.Post(srv.URL+"/v1/generate", "application/json", bytes.NewReader(b))
 	if err != nil {
 		t.Fatalf("post: %v", err)
 	}


### PR DESCRIPTION
## Summary
- consolidate generate, tags, and model endpoints under /v1
- keep worker connections and monitoring endpoints at root

## Testing
- `make build`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_689ad6314b84832ca618c5ab02110659