### PR TITLE
cmd: add version flags to server and worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,17 @@ go build -o .\bin\llamapool-server.exe .\cmd\llamapool-server
 go build -o .\bin\llamapool-worker.exe .\cmd\llamapool-worker
 ```
 
+### Version
+
+Both binaries expose a `--version` flag that prints the build metadata:
+
+```bash
+llamapool-server --version
+llamapool-worker --version
+```
+
+The output includes the version, git SHA and build date.
+
 ## Run
 
 ### Server

--- a/cmd/llamapool-server/main.go
+++ b/cmd/llamapool-server/main.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
+	"strings"
 	"syscall"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -24,10 +26,23 @@ var (
 	buildDate = "unknown"
 )
 
+func binaryName() string {
+	b := filepath.Base(os.Args[0])
+	if strings.HasPrefix(b, "llamapool-") {
+		return strings.TrimPrefix(b, "llamapool-")
+	}
+	return b
+}
+
 func main() {
+	showVersion := flag.Bool("version", false, "print version and exit")
 	var cfg config.ServerConfig
 	cfg.BindFlags()
 	flag.Parse()
+	if *showVersion {
+		fmt.Printf("llamapool-%s version=%s sha=%s date=%s\n", binaryName(), version, buildSHA, buildDate)
+		return
+	}
 
 	reg := ctrl.NewRegistry()
 	metricsReg := ctrl.NewMetricsRegistry(version, buildSHA, buildDate)

--- a/cmd/llamapool-worker/main.go
+++ b/cmd/llamapool-worker/main.go
@@ -3,8 +3,11 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
+	"strings"
 	"syscall"
 
 	"github.com/you/llamapool/internal/config"
@@ -12,10 +15,29 @@ import (
 	"github.com/you/llamapool/internal/worker"
 )
 
+var (
+	version   = "dev"
+	buildSHA  = "unknown"
+	buildDate = "unknown"
+)
+
+func binaryName() string {
+	b := filepath.Base(os.Args[0])
+	if strings.HasPrefix(b, "llamapool-") {
+		return strings.TrimPrefix(b, "llamapool-")
+	}
+	return b
+}
+
 func main() {
+	showVersion := flag.Bool("version", false, "print version and exit")
 	var cfg config.WorkerConfig
 	cfg.BindFlags()
 	flag.Parse()
+	if *showVersion {
+		fmt.Printf("llamapool-%s version=%s sha=%s date=%s\n", binaryName(), version, buildSHA, buildDate)
+		return
+	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 	defer stop()


### PR DESCRIPTION
## Summary
- add --version flag to server and worker binaries
- expose build metadata and helper to derive binary name
- document the version flag in README

## Testing
- `make lint` *(fails: errcheck, ineffassign, staticcheck)*
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689cf6ea346c832ca7ce077c8ef1956c