### PR TITLE
cmd: add version flags to server and worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,17 @@ go build -o .\bin\llamapool-server.exe .\cmd\llamapool-server
 go build -o .\bin\llamapool-worker.exe .\cmd\llamapool-worker
 ```
 
+### Version
+
+Both binaries expose a `--version` flag that prints the build metadata:
+
+```bash
+llamapool-server --version
+llamapool-worker --version
+```
+
+The output includes the version, git SHA and build date.
+
 ## Run
 
 ### Server

--- a/cmd/llamapool-server/main.go
+++ b/cmd/llamapool-server/main.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
+	"strings"
 	"syscall"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -24,10 +26,23 @@ var (
 	buildDate = "unknown"
 )
 
+func binaryName() string {
+	b := filepath.Base(os.Args[0])
+	if strings.HasPrefix(b, "llamapool-") {
+		return strings.TrimPrefix(b, "llamapool-")
+	}
+	return b
+}
+
 func main() {
+	showVersion := flag.Bool("version", false, "print version and exit")
 	var cfg config.ServerConfig
 	cfg.BindFlags()
 	flag.Parse()
+	if *showVersion {
+		fmt.Printf("llamapool-%s version=%s sha=%s date=%s\n", binaryName(), version, buildSHA, buildDate)
+		return
+	}
 
 	reg := ctrl.NewRegistry()
 	metricsReg := ctrl.NewMetricsRegistry(version, buildSHA, buildDate)
@@ -41,7 +56,9 @@ func main() {
 	defer stop()
 	go func() {
 		<-ctx.Done()
-		srv.Shutdown(context.Background())
+		if err := srv.Shutdown(context.Background()); err != nil {
+			logx.Log.Error().Err(err).Msg("server shutdown")
+		}
 	}()
 
 	if cfg.APIKey != "" {

--- a/cmd/llamapool-worker/main.go
+++ b/cmd/llamapool-worker/main.go
@@ -3,8 +3,11 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
+	"strings"
 	"syscall"
 
 	"github.com/you/llamapool/internal/config"
@@ -12,10 +15,29 @@ import (
 	"github.com/you/llamapool/internal/worker"
 )
 
+var (
+	version   = "dev"
+	buildSHA  = "unknown"
+	buildDate = "unknown"
+)
+
+func binaryName() string {
+	b := filepath.Base(os.Args[0])
+	if strings.HasPrefix(b, "llamapool-") {
+		return strings.TrimPrefix(b, "llamapool-")
+	}
+	return b
+}
+
 func main() {
+	showVersion := flag.Bool("version", false, "print version and exit")
 	var cfg config.WorkerConfig
 	cfg.BindFlags()
 	flag.Parse()
+	if *showVersion {
+		fmt.Printf("llamapool-%s version=%s sha=%s date=%s\n", binaryName(), version, buildSHA, buildDate)
+		return
+	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 	defer stop()

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,11 @@ go 1.23.0
 toolchain go1.24.3
 
 require (
+	github.com/coder/websocket v1.8.13
 	github.com/go-chi/chi/v5 v5.2.2
 	github.com/google/uuid v1.6.0
 	github.com/prometheus/client_golang v1.23.0
 	github.com/rs/zerolog v1.34.0
-	nhooyr.io/websocket v1.8.17
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/coder/websocket v1.8.13 h1:f3QZdXy7uGVz+4uCJy2nTZyM0yTBj8yANEHhqlXZ9FE=
+github.com/coder/websocket v1.8.13/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -50,5 +52,3 @@ google.golang.org/protobuf v1.36.6 h1:z1NpPI8ku2WgiWnf+t9wTPsn6eP1L7ksHUlkfLvd9x
 google.golang.org/protobuf v1.36.6/go.mod h1:jduwjTPXsFjZGTmRluh+L6NjiWu7pchiJ2/5YcXBHnY=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-nhooyr.io/websocket v1.8.17 h1:KEVeLJkUywCKVsnLIDlD/5gtayKp8VoCkksHCGGfT9Y=
-nhooyr.io/websocket v1.8.17/go.mod h1:rN9OFWIUwuxg4fR5tELlYC04bXYowCP9GX47ivo2l+c=

--- a/internal/api/generate.go
+++ b/internal/api/generate.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/you/llamapool/internal/ctrl"
+	"github.com/you/llamapool/internal/logx"
 	"github.com/you/llamapool/internal/relay"
 )
 
@@ -35,7 +36,9 @@ func GenerateHandler(reg *ctrl.Registry, sched ctrl.Scheduler, timeout time.Dura
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(res)
+		if err := json.NewEncoder(w).Encode(res); err != nil {
+			logx.Log.Error().Err(err).Msg("encode generate result")
+		}
 	}
 }
 
@@ -46,7 +49,9 @@ func handleRelayErr(w http.ResponseWriter, err error) {
 	case errors.Is(err, relay.ErrWorkerBusy):
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusServiceUnavailable)
-		json.NewEncoder(w).Encode(map[string]string{"error": "worker_busy"})
+		if err := json.NewEncoder(w).Encode(map[string]string{"error": "worker_busy"}); err != nil {
+			logx.Log.Error().Err(err).Msg("encode worker busy")
+		}
 	case errors.Is(err, context.DeadlineExceeded):
 		http.Error(w, "timeout", http.StatusGatewayTimeout)
 	default:

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -36,7 +36,9 @@ func APIKeyMiddleware(apiKey string) func(http.Handler) http.Handler {
 			if !strings.HasPrefix(auth, "Bearer ") || strings.TrimPrefix(auth, "Bearer ") != apiKey {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusUnauthorized)
-				w.Write([]byte(`{"error":"unauthorized"}`))
+				if _, err := w.Write([]byte(`{"error":"unauthorized"}`)); err != nil {
+					logx.Log.Error().Err(err).Msg("write unauthorized")
+				}
 				return
 			}
 			next.ServeHTTP(w, r)

--- a/internal/api/models.go
+++ b/internal/api/models.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"github.com/you/llamapool/internal/ctrl"
+	"github.com/you/llamapool/internal/logx"
 )
 
 // ListModelsHandler handles GET /v1/models.
@@ -29,7 +30,9 @@ func ListModelsHandler(reg *ctrl.Registry) http.HandlerFunc {
 			resp.Data = append(resp.Data, item{ID: m.ID, Object: "model", Created: m.Created, OwnedBy: strings.Join(m.Owners, ",")})
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			logx.Log.Error().Err(err).Msg("encode models list")
+		}
 	}
 }
 
@@ -41,7 +44,9 @@ func GetModelHandler(reg *ctrl.Registry) http.HandlerFunc {
 		w.Header().Set("Content-Type", "application/json")
 		if !ok {
 			w.WriteHeader(http.StatusNotFound)
-			json.NewEncoder(w).Encode(map[string]string{"error": "model_not_found"})
+			if err := json.NewEncoder(w).Encode(map[string]string{"error": "model_not_found"}); err != nil {
+				logx.Log.Error().Err(err).Msg("encode model not found")
+			}
 			return
 		}
 		resp := struct {
@@ -50,6 +55,8 @@ func GetModelHandler(reg *ctrl.Registry) http.HandlerFunc {
 			Created int64  `json:"created"`
 			OwnedBy string `json:"owned_by"`
 		}{ID: m.ID, Object: "model", Created: m.Created, OwnedBy: strings.Join(m.Owners, ",")}
-		json.NewEncoder(w).Encode(resp)
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			logx.Log.Error().Err(err).Msg("encode model detail")
+		}
 	}
 }

--- a/internal/api/state_test.go
+++ b/internal/api/state_test.go
@@ -46,7 +46,9 @@ func TestGetStateStream(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 	reader := bufio.NewReader(resp.Body)
 	line, err := reader.ReadString('\n')
 	if err != nil {

--- a/internal/api/tags.go
+++ b/internal/api/tags.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/you/llamapool/internal/ctrl"
+	"github.com/you/llamapool/internal/logx"
 )
 
 // TagsHandler handles GET /api/tags.
@@ -21,6 +22,8 @@ func TagsHandler(reg *ctrl.Registry) http.HandlerFunc {
 			resp.Models = append(resp.Models, m{Name: mod})
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			logx.Log.Error().Err(err).Msg("encode tags")
+		}
 	}
 }

--- a/internal/ctrl/metrics_test.go
+++ b/internal/ctrl/metrics_test.go
@@ -15,9 +15,7 @@ func TestSnapshotEmpty(t *testing.T) {
 	if snap.Server.JobsInflight != 0 || snap.Server.JobsCompletedTotal != 0 {
 		t.Fatalf("expected zero jobs")
 	}
-	if snap.Server.UptimeSeconds < 0 {
-		t.Fatalf("invalid uptime")
-	}
+	// uptime may be zero immediately after creation
 }
 
 func TestWorkerLifecycle(t *testing.T) {

--- a/internal/ctrl/ws_workername_test.go
+++ b/internal/ctrl/ws_workername_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"nhooyr.io/websocket"
+	"github.com/coder/websocket"
 )
 
 func TestRegisterStoresWorkerName(t *testing.T) {
@@ -22,10 +22,14 @@ func TestRegisterStoresWorkerName(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
-	defer conn.Close(websocket.StatusNormalClosure, "")
+	defer func() {
+		_ = conn.Close(websocket.StatusNormalClosure, "")
+	}()
 	rm := RegisterMessage{Type: "register", WorkerID: "w1abcdef", WorkerName: "Alpha", Models: []string{"m"}, MaxConcurrency: 1}
 	b, _ := json.Marshal(rm)
-	conn.Write(ctx, websocket.MessageText, b)
+	if err := conn.Write(ctx, websocket.MessageText, b); err != nil {
+		t.Fatalf("write: %v", err)
+	}
 	// wait for registration
 	for i := 0; i < 50; i++ {
 		reg.mu.RLock()
@@ -52,10 +56,14 @@ func TestRegisterFallbackName(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
-	defer conn.Close(websocket.StatusNormalClosure, "")
+	defer func() {
+		_ = conn.Close(websocket.StatusNormalClosure, "")
+	}()
 	rm := RegisterMessage{Type: "register", WorkerID: "w123456789", Models: []string{"m"}, MaxConcurrency: 1}
 	b, _ := json.Marshal(rm)
-	conn.Write(ctx, websocket.MessageText, b)
+	if err := conn.Write(ctx, websocket.MessageText, b); err != nil {
+		t.Fatalf("write: %v", err)
+	}
 	var name string
 	for i := 0; i < 50; i++ {
 		reg.mu.RLock()

--- a/internal/ollama/client.go
+++ b/internal/ollama/client.go
@@ -30,7 +30,9 @@ func (c *Client) Tags(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 	var v struct {
 		Models []struct {
 			Name string `json:"name"`
@@ -71,7 +73,9 @@ func (c *Client) Generate(ctx context.Context, req relay.GenerateRequest) ([]byt
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 	return io.ReadAll(resp.Body)
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/you/llamapool/internal/api"
 	"github.com/you/llamapool/internal/config"
 	"github.com/you/llamapool/internal/ctrl"
+	"github.com/you/llamapool/internal/logx"
 )
 
 // New constructs the HTTP handler for the server.
@@ -32,7 +33,9 @@ func New(reg *ctrl.Registry, metrics *ctrl.MetricsRegistry, sched ctrl.Scheduler
 	r.Handle(cfg.WSPath, ctrl.WSHandler(reg, cfg.WorkerKey))
 	r.Get("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"status":"ok"}`))
+		if _, err := w.Write([]byte(`{"status":"ok"}`)); err != nil {
+			logx.Log.Error().Err(err).Msg("write healthz")
+		}
 	})
 	r.Handle("/metrics", promhttp.Handler())
 

--- a/internal/worker/http_proxy.go
+++ b/internal/worker/http_proxy.go
@@ -57,7 +57,7 @@ func handleHTTPProxy(ctx context.Context, cfg config.WorkerConfig, sendCh chan [
 		sendProxyError(req.RequestID, sendCh, err)
 		return
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	hdrs := map[string]string{}
 	for k, v := range resp.Header {

--- a/internal/worker/http_proxy_test.go
+++ b/internal/worker/http_proxy_test.go
@@ -23,15 +23,21 @@ func TestHandleHTTPProxyAuthAndStream(t *testing.T) {
 			w.Header().Set("Content-Type", "text/event-stream")
 			w.WriteHeader(200)
 			fl := w.(http.Flusher)
-			w.Write([]byte("data: 1\n\n"))
+			if _, err := w.Write([]byte("data: 1\n\n")); err != nil {
+				t.Fatalf("write: %v", err)
+			}
 			fl.Flush()
-			w.Write([]byte("data: 2\n\n"))
+			if _, err := w.Write([]byte("data: 2\n\n")); err != nil {
+				t.Fatalf("write: %v", err)
+			}
 			fl.Flush()
 			return
 		}
 		if r.URL.Path == "/api/tags" {
 			w.Header().Set("Content-Type", "application/json")
-			w.Write([]byte(`{"models":[{"name":"llama3"}]}`))
+			if _, err := w.Write([]byte(`{"models":[{"name":"llama3"}]}`)); err != nil {
+				t.Fatalf("write: %v", err)
+			}
 			return
 		}
 		w.WriteHeader(404)
@@ -62,10 +68,14 @@ func TestHandleHTTPProxyAuthAndStream(t *testing.T) {
 		var env struct {
 			Type string `json:"type"`
 		}
-		json.Unmarshal(b, &env)
+		if err := json.Unmarshal(b, &env); err != nil {
+			t.Fatalf("unmarshal env: %v", err)
+		}
 		if env.Type == "http_proxy_response_chunk" {
 			var c ctrl.HTTPProxyResponseChunkMessage
-			json.Unmarshal(b, &c)
+			if err := json.Unmarshal(b, &c); err != nil {
+				t.Fatalf("unmarshal chunk: %v", err)
+			}
 			body = append(body, c.Data...)
 		} else if env.Type == "http_proxy_response_end" {
 			break

--- a/test/e2e_api_key_test.go
+++ b/test/e2e_api_key_test.go
@@ -27,7 +27,9 @@ func TestAPIKeyEnforcement(t *testing.T) {
 	if resp.StatusCode != http.StatusUnauthorized {
 		t.Fatalf("expected 401, got %d", resp.StatusCode)
 	}
-	resp.Body.Close()
+	if err := resp.Body.Close(); err != nil {
+		t.Fatalf("close body: %v", err)
+	}
 
 	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/v1/models", nil)
 	req.Header.Set("Authorization", "Bearer test123")
@@ -38,5 +40,7 @@ func TestAPIKeyEnforcement(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}
-	resp.Body.Close()
+	if err := resp.Body.Close(); err != nil {
+		t.Fatalf("close body: %v", err)
+	}
 }

--- a/test/e2e_busy_test.go
+++ b/test/e2e_busy_test.go
@@ -32,12 +32,16 @@ func TestWorkerBusy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("post: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 	if resp.StatusCode != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503, got %d", resp.StatusCode)
 	}
 	var v map[string]string
-	json.NewDecoder(resp.Body).Decode(&v)
+	if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
 	if v["error"] != "worker_busy" {
 		t.Fatalf("unexpected error body: %v", v)
 	}

--- a/test/e2e_prune_test.go
+++ b/test/e2e_prune_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"nhooyr.io/websocket"
+	"github.com/coder/websocket"
 
 	"github.com/you/llamapool/internal/config"
 	"github.com/you/llamapool/internal/ctrl"
@@ -30,10 +30,12 @@ func TestHeartbeatPrune(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
-	defer conn.Close(websocket.StatusNormalClosure, "")
+	defer func() { _ = conn.Close(websocket.StatusNormalClosure, "") }()
 	regMsg := ctrl.RegisterMessage{Type: "register", WorkerID: "w1", WorkerKey: "secret", Models: []string{"m"}, MaxConcurrency: 1}
 	b, _ := json.Marshal(regMsg)
-	conn.Write(ctx, websocket.MessageText, b)
+	if err := conn.Write(ctx, websocket.MessageText, b); err != nil {
+		t.Fatalf("write: %v", err)
+	}
 
 	// ensure registration
 	for i := 0; i < 50; i++ {

--- a/test/e2e_routes_test.go
+++ b/test/e2e_routes_test.go
@@ -25,13 +25,17 @@ func TestRoutes(t *testing.T) {
 	if err != nil || resp.StatusCode != http.StatusOK {
 		t.Fatalf("/api/tags: %v %d", err, resp.StatusCode)
 	}
-	resp.Body.Close()
+	if err := resp.Body.Close(); err != nil {
+		t.Fatalf("close body: %v", err)
+	}
 
 	resp, _ = http.Get(srv.URL + "/tags")
 	if resp.StatusCode != http.StatusNotFound {
 		t.Fatalf("expected 404 for /tags")
 	}
-	resp.Body.Close()
+	if err := resp.Body.Close(); err != nil {
+		t.Fatalf("close body: %v", err)
+	}
 
 	resp, err = http.Get(srv.URL + "/healthz")
 	if err != nil || resp.StatusCode != http.StatusOK {
@@ -40,8 +44,13 @@ func TestRoutes(t *testing.T) {
 	var v struct {
 		Status string `json:"status"`
 	}
-	json.NewDecoder(resp.Body).Decode(&v)
-	resp.Body.Close()
+	if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
+		_ = resp.Body.Close()
+		t.Fatalf("decode: %v", err)
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Fatalf("close body: %v", err)
+	}
 	if v.Status != "ok" {
 		t.Fatalf("bad health body")
 	}


### PR DESCRIPTION
## Summary
- add --version flag to server and worker binaries
- expose build metadata and helper to derive binary name
- document the version flag in README
- address golangci-lint warnings and switch to maintained coder/websocket library

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689cf6ea346c832ca7ce077c8ef1956c