### PR TITLE
Embed build metadata and show version in help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,15 @@
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+BUILD_SHA ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+BUILD_DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+
 .PHONY: build test lint generate
 
-LDFLAGS ?=
+LDFLAGS ?= -s -w -X main.version=$(VERSION) -X main.buildSHA=$(BUILD_SHA) -X main.buildDate=$(BUILD_DATE)
+GOFLAGS ?= -trimpath
 
 build:
-	go build -ldflags "$(LDFLAGS)" ./cmd/llamapool-server
-	go build -ldflags "$(LDFLAGS)" ./cmd/llamapool-worker
+	go build $(GOFLAGS) -ldflags "$(LDFLAGS)" ./cmd/llamapool-server
+	go build $(GOFLAGS) -ldflags "$(LDFLAGS)" ./cmd/llamapool-worker
 
 test:
 	go test ./... -race -count=1

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ llamapool-worker --version
 ```
 
 The output includes the version, git SHA and build date.
+The same version information appears at the top of `--help` output.
 
 ## Run
 

--- a/cmd/llamapool-server/main.go
+++ b/cmd/llamapool-server/main.go
@@ -38,6 +38,10 @@ func main() {
 	showVersion := flag.Bool("version", false, "print version and exit")
 	var cfg config.ServerConfig
 	cfg.BindFlags()
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "llamapool-%s version=%s sha=%s date=%s\n\n", binaryName(), version, buildSHA, buildDate)
+		flag.PrintDefaults()
+	}
 	flag.Parse()
 	if *showVersion {
 		fmt.Printf("llamapool-%s version=%s sha=%s date=%s\n", binaryName(), version, buildSHA, buildDate)

--- a/cmd/llamapool-worker/main.go
+++ b/cmd/llamapool-worker/main.go
@@ -33,6 +33,10 @@ func main() {
 	showVersion := flag.Bool("version", false, "print version and exit")
 	var cfg config.WorkerConfig
 	cfg.BindFlags()
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "llamapool-%s version=%s sha=%s date=%s\n\n", binaryName(), version, buildSHA, buildDate)
+		flag.PrintDefaults()
+	}
 	flag.Parse()
 	if *showVersion {
 		fmt.Printf("llamapool-%s version=%s sha=%s date=%s\n", binaryName(), version, buildSHA, buildDate)


### PR DESCRIPTION
## Summary
- Embed version, git SHA, and build date in compiled binaries via Makefile
- Display build metadata at top of `--help` output for server and worker
- Document that `--help` includes version information

## Testing
- `make build`
- `make test`
- `./llamapool-server --help | head -n 5`
- `./llamapool-worker --help | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_689d2e40e0b8832c889e106402ae3280