### PR TITLE
ci: build Debian packages

### DIFF
--- a/.github/workflows/release-deb.yml
+++ b/.github/workflows/release-deb.yml
@@ -1,0 +1,51 @@
+name: release-deb
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  build-deb:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+    env:
+      DEB_BUILD_OPTIONS: nocheck
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+          cache: true
+      - name: Install deb tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential devscripts debhelper dh-golang golang-any lintian
+      - name: Set Debian version from tag
+        id: v
+        run: |
+          TAG=${GITHUB_REF_NAME}
+          UPVER=${TAG#v}
+          echo "upver=$UPVER" >> $GITHUB_OUTPUT
+      - name: Update changelog
+        run: |
+          dch --create -v "${{ steps.v.outputs.upver }}-1" --package llamapool \
+            --distribution unstable "Release ${GITHUB_REF_NAME}"
+          cat debian/changelog
+      - name: Build (binary package only)
+        env:
+          DEB_BUILD_ARCH: ${{ matrix.arch }}
+          GOARCH: ${{ matrix.arch }}
+        run: |
+          dpkg-buildpackage -b -us -uc
+          mkdir -p out && mv ../*.deb out/
+      - name: Lintian
+        run: |
+          lintian out/*.deb || true
+      - name: Upload .deb to Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: out/*.deb
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/snapshot-deb.yml
+++ b/.github/workflows/snapshot-deb.yml
@@ -1,0 +1,44 @@
+name: snapshot-deb
+on:
+  push:
+    branches: ['main']
+  pull_request:
+
+jobs:
+  build-deb-snapshot:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+          cache: true
+      - name: Install deb tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential devscripts debhelper dh-golang golang-any
+      - name: Synthesize snapshot version
+        id: v
+        run: |
+          DATE=$(date -u +%Y%m%d)
+          SHA=$(git rev-parse --short HEAD)
+          echo "ver=1.3.0~git${DATE}+${SHA}-1" >> $GITHUB_OUTPUT
+      - name: Update changelog
+        run: |
+          dch --create -v "${{ steps.v.outputs.ver }}" --package llamapool \
+            --distribution unstable "Snapshot build"
+      - name: Build binary packages
+        env:
+          DEB_BUILD_ARCH: ${{ matrix.arch }}
+          GOARCH: ${{ matrix.arch }}
+        run: |
+          dpkg-buildpackage -b -us -uc
+          mkdir -p out && mv ../*.deb out/
+      - uses: actions/upload-artifact@v4
+        with:
+          name: debs-${{ matrix.arch }}-${{ steps.v.outputs.ver }}
+          path: out/*.deb
+          retention-days: 14

--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ A typical deployment looks like this:
 - **Worker authentication**: `WORKER_KEY` required for worker WebSocket registration.
 - **Transport**: run behind TLS (HTTPS/WSS) via reverse proxy or terminate TLS in-process.
 
+- **Service isolation**: Debian packages run the daemons as the dedicated `llamapool` user with systemd-managed directories
+  (`/var/lib/llamapool`, `/var/cache/llamapool`, `/run/llamapool`) and hardening flags like `NoNewPrivileges=true` and
+  `ProtectSystem=full`.
+
 ## Monitoring & Observability
 
 - **Prometheus** (`/metrics`):  
@@ -111,6 +115,13 @@ A typical deployment looks like this:
 - Enable **scalable and fault-tolerant** request routing across many workers.
 - Offer **transparent monitoring and metrics** for operational insight.
 
+## Install via .deb
+
+```bash
+wget https://github.com/gaspardpetit/llamapool/releases/download/v1.3.0/llamapool-server_1.3.0-1_amd64.deb
+sudo dpkg -i llamapool-server_1.3.0-1_amd64.deb
+sudo systemctl status llamapool-server
+```
 
 ## Build
 
@@ -242,8 +253,7 @@ Each file contains `KEY=value` pairs, for example:
 # WORKER_KEY=secret
 ```
 
-Template files with commented defaults are available under
-`deploy/systemd/` and can be copied into place as needed.
+Commented example files are installed to `/etc/llamapool/`; edit these files to configure the services.
 
 ## Example request
 


### PR DESCRIPTION
## Summary
- add release workflow that builds and uploads Debian packages on tagged releases
- add snapshot workflow to build Debian packages for main and PRs
- document .deb installation, service hardening, and config file locations

## Testing
- `make build`
- `make test`
- `dpkg-buildpackage -b -us -uc`
- `lintian ../llamapool-server_1.3.0-1_amd64.deb ../llamapool-worker_1.3.0-1_amd64.deb`


------
https://chatgpt.com/codex/tasks/task_e_689d391f69bc832ca4d1ac5500f986f0