### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: snapshot
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/gaspardpetit/llamapool/security/code-scanning/2](https://github.com/gaspardpetit/llamapool/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimal required permissions for the `GITHUB_TOKEN`. Since the workflow only needs to read repository contents (for checkout and build) and upload artifacts (which does not require additional permissions), the minimal required permission is `contents: read`. This block should be added at the top level of the workflow (just after the `name:` and before `on:`), so it applies to all jobs in the workflow. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
