### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/snapshot-deb.yml
+++ b/.github/workflows/snapshot-deb.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: snapshot-deb
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/gaspardpetit/llamapool/security/code-scanning/3](https://github.com/gaspardpetit/llamapool/security/code-scanning/3)

To fix the problem, add a `permissions` block to the workflow file `.github/workflows/snapshot-deb.yml`. This block should be placed at the top level (before `jobs:`) to apply to all jobs in the workflow, unless a job needs more specific permissions. The minimal required permission for this workflow is likely `contents: read`, as it checks out code and uploads artifacts but does not push changes or interact with issues or pull requests. No other permissions appear necessary based on the provided steps. No changes to existing functionality are required; this is a security hardening change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
