### PR TITLE
test: ensure worker version flag outputs build info

### DIFF
--- a/cmd/llamapool-worker/main_test.go
+++ b/cmd/llamapool-worker/main_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestVersionFlag(t *testing.T) {
+	const (
+		v    = "v0.0.1-test"
+		sha  = "abcdef"
+		date = "2000-01-02T03:04:05Z"
+	)
+	ldflags := fmt.Sprintf("-X main.version=%s -X main.buildSHA=%s -X main.buildDate=%s", v, sha, date)
+	cmd := exec.Command("go", "run", "-ldflags", ldflags, ".", "--version")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("command failed: %v\n%s", err, out)
+	}
+	got := strings.TrimSpace(string(out))
+	want := fmt.Sprintf("llamapool-worker version=%s sha=%s date=%s", v, sha, date)
+	if got != want {
+		t.Fatalf("unexpected output: got %q want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- add a test that verifies `llamapool-worker --version` prints ldflag-provided version, SHA, and build date

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689e046041c4832c9170055829f0b90b