### PR TITLE
worker: add ollama health probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,9 @@ When started with `--status-addr <addr>`, the worker serves local endpoints:
 - `GET /status` returns the current worker state.
 - `GET /version` returns build information.
 
+The worker periodically checks the local Ollama instance so that
+`connected_to_ollama` and `models` stay current in the `/status` output.
+
 ## Configuration
 
 When running as a systemd service, both components read optional configuration

--- a/internal/ollama/client.go
+++ b/internal/ollama/client.go
@@ -48,6 +48,12 @@ func (c *Client) Tags(ctx context.Context) ([]string, error) {
 	return models, nil
 }
 
+// Health checks the Ollama instance by fetching tags. Success indicates a
+// healthy Ollama and returns the list of available models.
+func (c *Client) Health(ctx context.Context) ([]string, error) {
+	return c.Tags(ctx)
+}
+
 func (c *Client) GenerateStream(ctx context.Context, req relay.GenerateRequest) (io.ReadCloser, error) {
 	b, _ := json.Marshal(req)
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+"/api/generate?stream=true", bytes.NewReader(b))

--- a/internal/worker/health_test.go
+++ b/internal/worker/health_test.go
@@ -1,0 +1,97 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+
+	"github.com/you/llamapool/internal/ollama"
+)
+
+// fakeHealthClient implements healthClient for unit tests.
+type fakeHealthClient struct {
+	models []string
+	err    error
+}
+
+func (f fakeHealthClient) Health(ctx context.Context) ([]string, error) {
+	return f.models, f.err
+}
+
+func TestProbeOllamaUpdatesState(t *testing.T) {
+	resetState()
+	probeOllama(context.Background(), fakeHealthClient{models: []string{"m1"}})
+	s := GetState()
+	if !s.ConnectedToOllama || len(s.Models) != 1 || s.LastError != "" {
+		t.Fatalf("expected healthy state, got %+v", s)
+	}
+	probeOllama(context.Background(), fakeHealthClient{models: []string{"m1", "m2"}})
+	s = GetState()
+	if len(s.Models) != 2 || s.Models[1] != "m2" {
+		t.Fatalf("models not updated: %+v", s.Models)
+	}
+	probeOllama(context.Background(), fakeHealthClient{err: errors.New("down")})
+	s = GetState()
+	if s.ConnectedToOllama || s.LastError == "" {
+		t.Fatalf("expected failure state, got %+v", s)
+	}
+}
+
+func TestHealthProbeIntegration(t *testing.T) {
+	resetState()
+	var healthy atomic.Bool
+	healthy.Store(true)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/tags" {
+			w.WriteHeader(404)
+			return
+		}
+		if !healthy.Load() {
+			w.WriteHeader(500)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"models":[{"name":"m1"}]}`))
+	}))
+	defer srv.Close()
+	client := ollama.New(srv.URL)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	addr, err := StartStatusServer(ctx, "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("start status server: %v", err)
+	}
+	startHealthProbe(ctx, client, 50*time.Millisecond)
+	time.Sleep(80 * time.Millisecond)
+	resp, err := http.Get("http://" + addr + "/status")
+	if err != nil {
+		t.Fatalf("get status: %v", err)
+	}
+	var st State
+	if err := json.NewDecoder(resp.Body).Decode(&st); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	_ = resp.Body.Close()
+	if !st.ConnectedToOllama {
+		t.Fatalf("expected connected")
+	}
+	healthy.Store(false)
+	time.Sleep(80 * time.Millisecond)
+	resp, err = http.Get("http://" + addr + "/status")
+	if err != nil {
+		t.Fatalf("get status: %v", err)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&st); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	_ = resp.Body.Close()
+	if st.ConnectedToOllama || st.LastError == "" {
+		t.Fatalf("expected disconnected with error, got %+v", st)
+	}
+}


### PR DESCRIPTION
## Summary
- add health check in Ollama client
- periodically probe Ollama and refresh models in worker
- document periodic health checks for `/status`

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689e0bca30b4832c9fba1484c89cff22