### PR TITLE
worker: add drain timeout and double-signal handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,11 @@ When started with `--status-addr <addr>`, the worker serves local endpoints:
 - `GET /status` returns the current worker state.
 - `GET /version` returns build information.
 
+Sending `SIGTERM` causes the worker to stop accepting new jobs and wait up to
+`--drain-timeout` (default 1m) for in-flight work to finish before exiting.
+Send `SIGTERM` again to terminate immediately. Set `--drain-timeout=0` to exit
+without waiting or `--drain-timeout=-1` to wait indefinitely.
+
 The worker periodically checks the local Ollama instance so that
 `connected_to_ollama` and `models` stay current in the `/status` output.
 

--- a/internal/config/worker.go
+++ b/internal/config/worker.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/google/uuid"
 )
@@ -18,6 +19,7 @@ type WorkerConfig struct {
 	WorkerID       string
 	WorkerName     string
 	StatusAddr     string
+	DrainTimeout   time.Duration
 }
 
 func (c *WorkerConfig) BindFlags() {
@@ -34,6 +36,11 @@ func (c *WorkerConfig) BindFlags() {
 	}
 	c.WorkerID = getEnv("WORKER_ID", "")
 	c.StatusAddr = getEnv("STATUS_ADDR", "")
+	if d, err := time.ParseDuration(getEnv("DRAIN_TIMEOUT", "1m")); err == nil {
+		c.DrainTimeout = d
+	} else {
+		c.DrainTimeout = time.Minute
+	}
 
 	host, err := os.Hostname()
 	if err != nil || host == "" {
@@ -49,4 +56,5 @@ func (c *WorkerConfig) BindFlags() {
 	flag.StringVar(&c.WorkerID, "worker-id", c.WorkerID, "worker identifier")
 	flag.StringVar(&c.WorkerName, "worker-name", c.WorkerName, "worker display name")
 	flag.StringVar(&c.StatusAddr, "status-addr", c.StatusAddr, "local status http listen address")
+	flag.DurationVar(&c.DrainTimeout, "drain-timeout", c.DrainTimeout, "time to wait for in-flight jobs on shutdown (-1 to wait indefinitely, 0 to exit immediately)")
 }

--- a/internal/worker/drain_integration_test.go
+++ b/internal/worker/drain_integration_test.go
@@ -1,0 +1,128 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/you/llamapool/internal/config"
+	"github.com/you/llamapool/internal/ctrl"
+	"github.com/you/llamapool/internal/relay"
+)
+
+func TestDrainAndTerminate(t *testing.T) {
+	resetState()
+	release := make(chan struct{})
+	started := make(chan struct{})
+	ollama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/tags":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"models":[{"name":"m1"}]}`))
+		case "/api/generate":
+			close(started)
+			<-release
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"done":true}`))
+		default:
+			w.WriteHeader(404)
+		}
+	}))
+	defer ollama.Close()
+
+	connCh := make(chan *websocket.Conn, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Fatalf("accept: %v", err)
+		}
+		connCh <- c
+	}))
+	defer srv.Close()
+	wsURL := "ws://" + srv.Listener.Addr().String()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	statusAddr := ln.Addr().String()
+	_ = ln.Close()
+
+	cfg := config.WorkerConfig{ServerURL: wsURL, OllamaBaseURL: ollama.URL, MaxConcurrency: 1, StatusAddr: statusAddr}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() { errCh <- Run(ctx, cfg) }()
+
+	srvConn := <-connCh
+	ctxR, cancelR := context.WithTimeout(context.Background(), time.Second)
+	defer cancelR()
+	if _, _, err := srvConn.Read(ctxR); err != nil { // register
+		t.Fatalf("read register: %v", err)
+	}
+
+	jr1 := ctrl.JobRequestMessage{Type: "job_request", JobID: "j1", Endpoint: "generate", Payload: relay.GenerateRequest{Model: "m1", Prompt: "hi"}}
+	b1, _ := json.Marshal(jr1)
+	if err := srvConn.Write(context.Background(), websocket.MessageText, b1); err != nil {
+		t.Fatalf("write j1: %v", err)
+	}
+
+	<-started
+	StartDrain()
+
+	jr2 := ctrl.JobRequestMessage{Type: "job_request", JobID: "j2", Endpoint: "generate", Payload: relay.GenerateRequest{Model: "m1", Prompt: "hi"}}
+	b2, _ := json.Marshal(jr2)
+	if err := srvConn.Write(context.Background(), websocket.MessageText, b2); err != nil {
+		t.Fatalf("write j2: %v", err)
+	}
+
+	gotErr := false
+	for !gotErr {
+		_, msg, err := srvConn.Read(context.Background())
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		var env struct {
+			Type string `json:"type"`
+		}
+		if err := json.Unmarshal(msg, &env); err != nil {
+			continue
+		}
+		if env.Type == "job_error" {
+			var je ctrl.JobErrorMessage
+			_ = json.Unmarshal(msg, &je)
+			if je.JobID == "j2" && je.Code == "worker_draining" {
+				gotErr = true
+			}
+		}
+	}
+
+	resp, err := http.Get("http://" + statusAddr + "/status")
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	var st State
+	if err := json.NewDecoder(resp.Body).Decode(&st); err != nil {
+		t.Fatalf("decode status: %v", err)
+	}
+	_ = resp.Body.Close()
+	if st.State != "draining" || st.CurrentJobs != 1 {
+		t.Fatalf("unexpected status %+v", st)
+	}
+
+	close(release)
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("run error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timeout waiting for worker exit")
+	}
+}

--- a/internal/worker/drain_test.go
+++ b/internal/worker/drain_test.go
@@ -1,0 +1,18 @@
+package worker
+
+import "testing"
+
+func TestStartDrain(t *testing.T) {
+	resetState()
+	SetConnectedToServer(true)
+	SetState("connected_idle")
+	StartDrain()
+	if !IsDraining() || GetState().State != "draining" {
+		t.Fatalf("unexpected state: %+v", GetState())
+	}
+	IncJobs()
+	_ = DecJobs()
+	if GetState().State != "draining" {
+		t.Fatalf("state should remain draining")
+	}
+}

--- a/internal/worker/http_proxy.go
+++ b/internal/worker/http_proxy.go
@@ -14,7 +14,7 @@ import (
 	"github.com/you/llamapool/internal/logx"
 )
 
-func handleHTTPProxy(ctx context.Context, cfg config.WorkerConfig, sendCh chan []byte, req ctrl.HTTPProxyRequestMessage, cancels map[string]context.CancelFunc, mu *sync.Mutex) {
+func handleHTTPProxy(ctx context.Context, cfg config.WorkerConfig, sendCh chan []byte, req ctrl.HTTPProxyRequestMessage, cancels map[string]context.CancelFunc, mu *sync.Mutex, onDone func()) {
 	reqCtx, cancel := context.WithCancel(ctx)
 	mu.Lock()
 	cancels[req.RequestID] = cancel
@@ -25,7 +25,8 @@ func handleHTTPProxy(ctx context.Context, cfg config.WorkerConfig, sendCh chan [
 		mu.Lock()
 		delete(cancels, req.RequestID)
 		mu.Unlock()
-		DecJobs()
+		_ = DecJobs()
+		onDone()
 	}()
 
 	logx.Log.Info().Str("request_id", req.RequestID).Msg("proxy start")

--- a/internal/worker/http_proxy_test.go
+++ b/internal/worker/http_proxy_test.go
@@ -51,7 +51,7 @@ func TestHandleHTTPProxyAuthAndStream(t *testing.T) {
 	var mu sync.Mutex
 	req := ctrl.HTTPProxyRequestMessage{Type: "http_proxy_request", RequestID: "r1", Method: http.MethodPost, Path: "/v1/chat/completions", Headers: map[string]string{"Content-Type": "application/json"}, Stream: true, Body: []byte(`{}`)}
 	ctx := context.Background()
-	go handleHTTPProxy(ctx, cfg, sendCh, req, cancels, &mu)
+	go handleHTTPProxy(ctx, cfg, sendCh, req, cancels, &mu, func() {})
 
 	// headers
 	b := <-sendCh

--- a/internal/worker/status_http_test.go
+++ b/internal/worker/status_http_test.go
@@ -19,7 +19,6 @@ func TestStatusHTTP(t *testing.T) {
 	}
 	SetConnectedToServer(true)
 	SetState("connected_idle")
-	IncJobs()
 	resp, err := http.Get("http://" + addr + "/status")
 	if err != nil {
 		t.Fatalf("get status: %v", err)
@@ -29,7 +28,7 @@ func TestStatusHTTP(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&st); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if st.CurrentJobs != 1 || st.State != "connected_busy" {
+	if st.State != "connected_idle" || !st.ConnectedToServer {
 		t.Fatalf("unexpected state: %+v", st)
 	}
 	respV, err := http.Get("http://" + addr + "/version")

--- a/internal/worker/status_test.go
+++ b/internal/worker/status_test.go
@@ -14,7 +14,7 @@ func TestStateTransitions(t *testing.T) {
 	if s.CurrentJobs != 1 || s.State != "connected_busy" {
 		t.Fatalf("expected busy state, got %+v", s)
 	}
-	DecJobs()
+	_ = DecJobs()
 	s = GetState()
 	if s.CurrentJobs != 0 || s.State != "connected_idle" {
 		t.Fatalf("expected idle state, got %+v", s)


### PR DESCRIPTION
## Summary
- replace `--drain`/`--terminate-after-drain` with a single `--drain-timeout` flag and env var
- start draining on first SIGTERM and exit on second signal or when the timeout elapses
- document how `--drain-timeout` controls shutdown behavior

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689e1a7db020832c8ef4f267c34fe60c