### PR TITLE
feat: add OS-specific defaults for worker config and logs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md
 
 ## Project Overview
-Llamapool provides a minimal Ollama-compatible server with a pool of workers that proxy
+llamapool provides a minimal Ollama-compatible server with a pool of workers that proxy
 requests to local Ollama instances. The repository contains two binaries:
 - `llamapool-server`: hosts the public HTTP API and coordinates workers over WebSocket
 - `llamapool-worker`: connects to the server and forwards requests to a local Ollama
@@ -16,6 +16,7 @@ requests to local Ollama instances. The repository contains two binaries:
 - Use standard Go formatting via `gofmt -w` or `go fmt`
 - Prefer clarity over cleverness; keep functions small and well named
 - Default to the patterns already present in the `internal/` packages
+- Use lowercase `llamapool` in documentation and text unless referring to binaries or package names
 
 ## Testing Guidelines
 - Unit tests live alongside the code using `*_test.go` files

--- a/README.md
+++ b/README.md
@@ -276,6 +276,17 @@ Each file contains `KEY=value` pairs, for example:
 
 Commented example files are installed to `/etc/llamapool/`; edit these files to configure the services.
 
+When no explicit paths are provided, the worker falls back to OS defaults for
+its configuration and logs:
+
+- **macOS:** `~/Library/Application Support/llamapool/worker.yaml` and
+  `~/Library/Logs/llamapool/`
+- **Windows:** `%ProgramData%\llamapool\worker.yaml` and
+  `%ProgramData%\llamapool\Logs\`
+
+These locations can be overridden via the `CONFIG_FILE` and `LOG_DIR`
+environment variables or the `--config` and `--log-dir` flags.
+
 ## Example request
 
 Ensure that the requested `model` is installed on the connected worker's local

--- a/debian/control
+++ b/debian/control
@@ -10,11 +10,11 @@ Rules-Requires-Root: no
 Package: llamapool-server
 Architecture: any
 Depends: ${misc:Depends}, adduser
-Description: Llamapool server component (daemon)
- The server for Llamapool.
+Description: llamapool server component (daemon)
+ The server for llamapool.
 
 Package: llamapool-worker
 Architecture: any
 Depends: ${misc:Depends}, adduser
-Description: Llamapool worker component (daemon)
- The worker for Llamapool.
+Description: llamapool worker component (daemon)
+ The worker for llamapool.

--- a/debian/llamapool-server.service
+++ b/debian/llamapool-server.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Llamapool Server
+Description=llamapool server
 After=network-online.target
 Wants=network-online.target
 

--- a/debian/llamapool-worker.service
+++ b/debian/llamapool-worker.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Llamapool Worker
+Description=llamapool worker
 After=network-online.target
 Wants=network-online.target
 

--- a/deploy/systemd/llamapool-server.service
+++ b/deploy/systemd/llamapool-server.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Llamapool Server
+Description=llamapool server
 After=network-online.target
 Wants=network-online.target
 

--- a/deploy/systemd/llamapool-worker.service
+++ b/deploy/systemd/llamapool-worker.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Llamapool Worker
+Description=llamapool worker
 After=network-online.target
 Wants=network-online.target
 

--- a/internal/config/worker_test.go
+++ b/internal/config/worker_test.go
@@ -1,0 +1,58 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolveWorkerPaths(t *testing.T) {
+	tests := []struct {
+		name        string
+		goos        string
+		home        string
+		programData string
+		wantConfig  string
+		wantLogDir  string
+	}{
+		{
+			name:       "linux",
+			goos:       "linux",
+			home:       "/home/user",
+			wantConfig: "",
+			wantLogDir: "",
+		},
+		{
+			name:       "darwin",
+			goos:       "darwin",
+			home:       "/Users/test",
+			wantConfig: "/Users/test/Library/Application Support/llamapool/worker.yaml",
+			wantLogDir: "/Users/test/Library/Logs/llamapool",
+		},
+		{
+			name:        "windows",
+			goos:        "windows",
+			programData: "C:\\ProgramData",
+			wantConfig:  "C:/ProgramData/llamapool/worker.yaml",
+			wantLogDir:  "C:/ProgramData/llamapool/Logs",
+		},
+		{
+			name:       "windows default ProgramData",
+			goos:       "windows",
+			wantConfig: "C:/ProgramData/llamapool/worker.yaml",
+			wantLogDir: "C:/ProgramData/llamapool/Logs",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, log := resolveWorkerPaths(tt.goos, tt.home, tt.programData)
+			cfg = strings.ReplaceAll(cfg, "\\", "/")
+			log = strings.ReplaceAll(log, "\\", "/")
+			if cfg != tt.wantConfig {
+				t.Errorf("config path: got %q want %q", cfg, tt.wantConfig)
+			}
+			if log != tt.wantLogDir {
+				t.Errorf("log dir: got %q want %q", log, tt.wantLogDir)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add per-OS default paths for worker config file and logs
- expose --config and --log-dir flags with env overrides
- document macOS and Windows defaults in README
- test default path resolution across GOOS
- standardize documentation and service files to use lowercase 'llamapool'
- note lowercase usage in AGENTS guidelines

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689e33a7d8c0832cb227c97393f04ff5