### PR TITLE
Add Windows service wrapper and config paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,14 @@ go test ./...
 
 ## Windows integration (experimental)
 
-An initial Windows tray application and service wrapper live under `desktop/windows/`. The tray app hosts a tray icon with placeholder menu items for controlling a future worker.
+An initial Windows tray application and service wrapper live under `desktop/windows/`.
+The service wrapper launches `llamapool-worker.exe` installed at
+`%ProgramFiles%\llamapool\llamapool-worker.exe` with its working directory set to
+`%ProgramData%\llamapool`. Configuration is read from
+`%ProgramData%\llamapool\worker.yaml` and log output is written to
+`%ProgramData%\llamapool\Logs\worker.log`. The service is registered as
+`llamapool` with delayed automatic start. The tray app currently hosts a tray icon
+with placeholder menu items for controlling the worker.
 
 ## Currently Supported
 

--- a/desktop/windows/TrayApp/Paths.cs
+++ b/desktop/windows/TrayApp/Paths.cs
@@ -1,0 +1,25 @@
+using System;
+using System.IO;
+
+namespace TrayApp;
+
+/// <summary>
+/// Well-known locations for the Windows worker service.
+/// </summary>
+public static class Paths
+{
+    public static readonly string ProgramDataDir =
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "llamapool");
+
+    public static readonly string LogsDir = Path.Combine(ProgramDataDir, "Logs");
+
+    public static readonly string ConfigPath = Path.Combine(ProgramDataDir, "worker.yaml");
+
+    public static readonly string LogPath = Path.Combine(LogsDir, "worker.log");
+
+    public static readonly string BinaryPath = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
+        "llamapool",
+        "llamapool-worker.exe");
+}
+

--- a/desktop/windows/WindowsService/Program.cs
+++ b/desktop/windows/WindowsService/Program.cs
@@ -2,7 +2,10 @@ using Microsoft.Extensions.Hosting.WindowsServices;
 using WindowsService;
 
 var builder = Host.CreateApplicationBuilder(args);
-builder.Services.AddWindowsService();
+builder.Services.AddWindowsService(options =>
+{
+    options.ServiceName = "llamapool";
+});
 builder.Services.AddHostedService<Worker>();
 
 var host = builder.Build();

--- a/desktop/windows/WindowsService/Worker.cs
+++ b/desktop/windows/WindowsService/Worker.cs
@@ -1,8 +1,12 @@
+using System.Diagnostics;
+using System.IO;
+
 namespace WindowsService;
 
 public class Worker : BackgroundService
 {
     private readonly ILogger<Worker> _logger;
+    private Process? _process;
 
     public Worker(ILogger<Worker> logger)
     {
@@ -11,13 +15,68 @@ public class Worker : BackgroundService
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        while (!stoppingToken.IsCancellationRequested)
+        var programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+        var workerExe = Path.Combine(programFiles, "llamapool", "llamapool-worker.exe");
+
+        var programData = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
+        var dataDir = Path.Combine(programData, "llamapool");
+        Directory.CreateDirectory(dataDir);
+
+        var logsDir = Path.Combine(dataDir, "Logs");
+        Directory.CreateDirectory(logsDir);
+
+        var configPath = Path.Combine(dataDir, "worker.yaml");
+        var logPath = Path.Combine(logsDir, "worker.log");
+
+        var psi = new ProcessStartInfo
         {
-            if (_logger.IsEnabled(LogLevel.Information))
-            {
-                _logger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
-            }
-            await Task.Delay(1000, stoppingToken);
+            FileName = workerExe,
+            Arguments = $"--status-addr 127.0.0.1:4555 --config \"{configPath}\"",
+            WorkingDirectory = dataDir,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        _process = new Process { StartInfo = psi, EnableRaisingEvents = true };
+
+        try
+        {
+            _process.Start();
+
+            using var logWriter = TextWriter.Synchronized(new StreamWriter(logPath, append: true));
+            _process.OutputDataReceived += (_, e) => { if (e.Data != null) logWriter.WriteLine(e.Data); };
+            _process.ErrorDataReceived += (_, e) => { if (e.Data != null) logWriter.WriteLine(e.Data); };
+            _process.BeginOutputReadLine();
+            _process.BeginErrorReadLine();
+
+            await _process.WaitForExitAsync(stoppingToken);
         }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to run worker process");
+        }
+    }
+
+    public override Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (_process != null && !_process.HasExited)
+        {
+            try
+            {
+                _process.CloseMainWindow();
+                if (!_process.WaitForExit(5000))
+                {
+                    _process.Kill();
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to stop worker process gracefully");
+            }
+        }
+
+        return base.StopAsync(cancellationToken);
     }
 }


### PR DESCRIPTION
## Summary
- run llamapool-worker as a Windows service
- define standard config, log, and binary paths for the Windows tray app
- document Windows service model and paths

## Testing
- `dotnet build desktop/windows/Llamapool.Windows.sln` *(fails: command not found)*
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689e3a14eaa4832c9694ce9a71a7f170