### PR TITLE
feat(macos): manage worker LaunchAgent

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A typical deployment looks like this:
 
 ## macOS Menu Bar App
 
-An early-stage macOS menu bar companion lives under `desktop/macos/llamapool/`. It polls `http://127.0.0.1:4555/status` every two seconds to display live worker status and offers placeholder controls for managing a local `llamapool-worker`.
+An early-stage macOS menu bar companion lives under `desktop/macos/llamapool/`. It polls `http://127.0.0.1:4555/status` every two seconds to display live worker status and can manage a per-user LaunchAgent to start or stop a local `llamapool-worker` and toggle launching at login.
 The app icon is stored as a base64 file (`AppIcon.png.b64`); decode it to `AppIcon.png` before building.
 
 ### Key features

--- a/desktop/macos/llamapool/llamapool.xcodeproj/project.pbxproj
+++ b/desktop/macos/llamapool/llamapool.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
     77EE2F6323744EB4AF1E26772BAA8DF7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DB20D9050486454BA6F1464F12F231D1 /* Assets.xcassets */; };
     4AB0C8F71A2346C8B30B5E02 /* StatusClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6F8C39D6E9C4E14A5D0E2D9 /* StatusClient.swift */; };
     B21ACD2F315B40E38B7B6A6E /* StatusClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EAD688B5AC2497F99047482 /* StatusClientTests.swift */; };
+    3C5A9DCC93AC47D2A548BBF1F8E26370 /* LaunchAgentManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F4338ED4FF54C8F9A7491F083790C23 /* LaunchAgentManager.swift */; };
+    5D748F4BE7C9450EAD7714010E8AA9F8 /* io.llamapool.worker.plist.template in Resources */ = {isa = PBXBuildFile; fileRef = 911230C1E6D64B889FDC9BC0A8E368F2 /* io.llamapool.worker.plist.template */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -20,6 +22,8 @@
     D6F8C39D6E9C4E14A5D0E2D9 /* StatusClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusClient.swift; sourceTree = "<group>"; };
     4EAD688B5AC2497F99047482 /* StatusClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusClientTests.swift; sourceTree = "<group>"; };
     9FDC5B0B495D4A6C8C96F2E9 /* llamapoolTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = llamapoolTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+    6F4338ED4FF54C8F9A7491F083790C23 /* LaunchAgentManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchAgentManager.swift; sourceTree = "<group>"; };
+    911230C1E6D64B889FDC9BC0A8E368F2 /* io.llamapool.worker.plist.template */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = io.llamapool.worker.plist.template; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -41,11 +45,21 @@
       isa = PBXGroup;
       children = (
         9B993A0AF20C45B9BFF02576573C7A4D /* AppDelegate.swift */,
+        6F4338ED4FF54C8F9A7491F083790C23 /* LaunchAgentManager.swift */,
         D6F8C39D6E9C4E14A5D0E2D9 /* StatusClient.swift */,
         DB20D9050486454BA6F1464F12F231D1 /* Assets.xcassets */,
         24B6B6BC5ECD4E9CA7C7F7E8086B9FA5 /* Info.plist */,
+        B3A7F042CB5C4B0891846F5A8C13A01F /* Resources */,
       );
       path = llamapool;
+      sourceTree = "<group>";
+    };
+    B3A7F042CB5C4B0891846F5A8C13A01F /* Resources */ = {
+      isa = PBXGroup;
+      children = (
+        911230C1E6D64B889FDC9BC0A8E368F2 /* io.llamapool.worker.plist.template */,
+      );
+      path = Resources;
       sourceTree = "<group>";
     };
     B6510F4A0DAF4274A96E1F24 /* llamapoolTests */ = {
@@ -151,6 +165,7 @@
       buildActionMask = 2147483647;
       files = (
         77EE2F6323744EB4AF1E26772BAA8DF7 /* Assets.xcassets in Resources */,
+        5D748F4BE7C9450EAD7714010E8AA9F8 /* io.llamapool.worker.plist.template in Resources */,
       );
       runOnlyForDeploymentPostprocessing = 0;
     };
@@ -163,6 +178,7 @@
       files = (
         0CC07EE6BD4045DDAE821661FA6666E4 /* AppDelegate.swift in Sources */,
         4AB0C8F71A2346C8B30B5E02 /* StatusClient.swift in Sources */,
+        3C5A9DCC93AC47D2A548BBF1F8E26370 /* LaunchAgentManager.swift in Sources */,
       );
       runOnlyForDeploymentPostprocessing = 0;
     };

--- a/desktop/macos/llamapool/llamapool/AppDelegate.swift
+++ b/desktop/macos/llamapool/llamapool/AppDelegate.swift
@@ -10,6 +10,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var jobsItem: NSMenuItem!
     var lastErrorItem: NSMenuItem!
     var statusClient: StatusClient?
+    var loginItem: NSMenuItem!
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
@@ -41,8 +42,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         menu.addItem(NSMenuItem.separator())
         menu.addItem(NSMenuItem(title: "Preferences…", action: #selector(openPreferences), keyEquivalent: ","))
         menu.addItem(NSMenuItem(title: "Logs…", action: #selector(openLogs), keyEquivalent: "l"))
-        let loginItem = NSMenuItem(title: "Start at Login", action: #selector(toggleStartAtLogin), keyEquivalent: "")
-        loginItem.state = .off
+        loginItem = NSMenuItem(title: "Start at Login", action: #selector(toggleStartAtLogin), keyEquivalent: "")
+        loginItem.state = LaunchAgentManager.shared.isRunAtLoadEnabled() ? .on : .off
         menu.addItem(loginItem)
         menu.addItem(NSMenuItem(title: "Check for Updates", action: #selector(checkForUpdates), keyEquivalent: ""))
         menu.addItem(NSMenuItem.separator())
@@ -112,11 +113,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc func startWorker(_ sender: Any?) {
-        print("Start Worker clicked")
+        do {
+            try LaunchAgentManager.shared.start()
+        } catch {
+            print("Failed to start worker: \(error)")
+        }
     }
 
     @objc func stopWorker(_ sender: Any?) {
-        print("Stop Worker clicked")
+        do {
+            try LaunchAgentManager.shared.stop()
+        } catch {
+            print("Failed to stop worker: \(error)")
+        }
     }
 
     @objc func openPreferences(_ sender: Any?) {
@@ -128,8 +137,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc func toggleStartAtLogin(_ sender: NSMenuItem) {
-        sender.state = sender.state == .on ? .off : .on
-        print("Start at Login toggled")
+        let enable = sender.state == .off
+        do {
+            try LaunchAgentManager.shared.setRunAtLoad(enable)
+            sender.state = enable ? .on : .off
+        } catch {
+            print("Failed to toggle Start at Login: \(error)")
+        }
     }
 
     @objc func checkForUpdates(_ sender: Any?) {

--- a/desktop/macos/llamapool/llamapool/LaunchAgentManager.swift
+++ b/desktop/macos/llamapool/llamapool/LaunchAgentManager.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+class LaunchAgentManager {
+    static let shared = LaunchAgentManager()
+
+    private let fileManager = FileManager.default
+    private let label = "io.llamapool.worker"
+
+    private var launchAgentURL: URL {
+        fileManager.homeDirectoryForCurrentUser.appendingPathComponent("Library/LaunchAgents/\(label).plist")
+    }
+
+    private var logsDirURL: URL {
+        fileManager.homeDirectoryForCurrentUser.appendingPathComponent("Library/Logs/Llamapool")
+    }
+
+    private var configDirURL: URL {
+        fileManager.homeDirectoryForCurrentUser.appendingPathComponent("Library/Application Support/Llamapool")
+    }
+
+    private var workerBinaryURL: URL {
+        Bundle.main.resourceURL!.appendingPathComponent("bin/llamapool-worker")
+    }
+
+    private var templateURL: URL? {
+        Bundle.main.url(forResource: "io.llamapool.worker", withExtension: "plist.template")
+    }
+
+    func start() throws {
+        try installAgentIfNeeded()
+        try runLaunchctl(["load", launchAgentURL.path])
+        try runLaunchctl(["start", label])
+    }
+
+    func stop() throws {
+        try runLaunchctl(["stop", label])
+        try runLaunchctl(["unload", launchAgentURL.path])
+    }
+
+    func setRunAtLoad(_ enabled: Bool) throws {
+        try installAgentIfNeeded()
+        if let dict = NSMutableDictionary(contentsOf: launchAgentURL) {
+            dict["RunAtLoad"] = enabled
+            dict.write(to: launchAgentURL, atomically: true)
+            try runLaunchctl(["unload", launchAgentURL.path])
+            try runLaunchctl(["load", launchAgentURL.path])
+        }
+    }
+
+    func isRunAtLoadEnabled() -> Bool {
+        if let dict = NSDictionary(contentsOf: launchAgentURL) {
+            return dict["RunAtLoad"] as? Bool ?? false
+        }
+        return false
+    }
+
+    func isAgentLoaded() -> Bool {
+        (try? runLaunchctl(["list", label]).exitCode) == 0
+    }
+
+    private func installAgentIfNeeded() throws {
+        if !fileManager.fileExists(atPath: launchAgentURL.path) {
+            try fileManager.createDirectory(at: launchAgentURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try fileManager.createDirectory(at: logsDirURL, withIntermediateDirectories: true)
+            try fileManager.createDirectory(at: configDirURL, withIntermediateDirectories: true)
+            if let templateURL = templateURL {
+                var content = try String(contentsOf: templateURL)
+                content = content.replacingOccurrences(of: "{{WORKER_PATH}}", with: workerBinaryURL.path)
+                content = content.replacingOccurrences(of: "{{LOG_DIR}}", with: logsDirURL.path)
+                try content.write(to: launchAgentURL, atomically: true, encoding: .utf8)
+            }
+        }
+    }
+
+    @discardableResult
+    private func runLaunchctl(_ arguments: [String]) throws -> (output: String, exitCode: Int32) {
+        let process = Process()
+        process.launchPath = "/bin/launchctl"
+        process.arguments = arguments
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        try process.run()
+        process.waitUntilExit()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: data, encoding: .utf8) ?? ""
+        return (output, process.terminationStatus)
+    }
+}

--- a/desktop/macos/llamapool/llamapool/Resources/io.llamapool.worker.plist.template
+++ b/desktop/macos/llamapool/llamapool/Resources/io.llamapool.worker.plist.template
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>io.llamapool.worker</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{WORKER_PATH}}</string>
+        <string>--status-addr</string>
+        <string>127.0.0.1:4555</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>{{LOG_DIR}}/worker.out</string>
+    <key>StandardErrorPath</key>
+    <string>{{LOG_DIR}}/worker.err</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- manage per-user LaunchAgent for the worker via new LaunchAgentManager
- hook Start/Stop/Start at Login menu actions into LaunchAgent control
- add LaunchAgent template resource and document macOS app capabilities

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689e4baa6bf0832cb0a103f462e04cf1