### PR TITLE
Add worker status polling to Windows tray app

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,8 +374,9 @@ The service wrapper launches `llamapool-worker.exe` installed at
 `%ProgramData%\llamapool`. Configuration is read from
 `%ProgramData%\llamapool\worker.yaml` and log output is written to
 `%ProgramData%\llamapool\Logs\worker.log`. The service is registered as
-`llamapool` with delayed automatic start. The tray app currently hosts a tray icon
-with placeholder menu items for controlling the worker.
+`llamapool` with delayed automatic start. The tray app now polls the local worker
+every two seconds and updates its menu and tooltip to reflect the current status.
+A details dialog shows connection information, job counts, and any last error.
 
 ## Currently Supported
 

--- a/desktop/windows/Llamapool.Windows.sln
+++ b/desktop/windows/Llamapool.Windows.sln
@@ -8,6 +8,8 @@ Project("{B7DD6F7E-DEF8-4E67-B5B7-07EF123DB6F0}") = "Installer", "Installer\Inst
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TrayApp", "TrayApp\TrayApp.csproj", "{558CDF6E-0C52-4AFE-B20F-404054CE6F74}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TrayApp.Tests", "TrayApp.Tests\TrayApp.Tests.csproj", "{129DD78F-922E-4B32-917E-109D39E954EF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -23,10 +25,14 @@ Global
 		{A4B3D7AC-FFDD-43CE-8286-F96613DC6647}.Release|Any CPU.ActiveCfg = Release|x64
 		{A4B3D7AC-FFDD-43CE-8286-F96613DC6647}.Release|Any CPU.Build.0 = Release|x64
 		{558CDF6E-0C52-4AFE-B20F-404054CE6F74}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{558CDF6E-0C52-4AFE-B20F-404054CE6F74}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{558CDF6E-0C52-4AFE-B20F-404054CE6F74}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{558CDF6E-0C52-4AFE-B20F-404054CE6F74}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {558CDF6E-0C52-4AFE-B20F-404054CE6F74}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {558CDF6E-0C52-4AFE-B20F-404054CE6F74}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {558CDF6E-0C52-4AFE-B20F-404054CE6F74}.Release|Any CPU.Build.0 = Release|Any CPU
+                {129DD78F-922E-4B32-917E-109D39E954EF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {129DD78F-922E-4B32-917E-109D39E954EF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {129DD78F-922E-4B32-917E-109D39E954EF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {129DD78F-922E-4B32-917E-109D39E954EF}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/desktop/windows/TrayApp.Tests/TrayApp.Tests.csproj
+++ b/desktop/windows/TrayApp.Tests/TrayApp.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\TrayApp\StatusClient.cs" Link="StatusClient.cs" />
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+  </ItemGroup>
+</Project>

--- a/desktop/windows/TrayApp.Tests/WorkerStatusTests.cs
+++ b/desktop/windows/TrayApp.Tests/WorkerStatusTests.cs
@@ -1,0 +1,32 @@
+using System.Text.Json;
+using TrayApp;
+using Xunit;
+
+public class WorkerStatusTests
+{
+    private const string SampleJson = """
+    {
+      "state": "connected_idle",
+      "connected_to_server": true,
+      "connected_to_ollama": true,
+      "current_jobs": 1,
+      "max_concurrency": 2,
+      "models": ["llama3"],
+      "last_error": "",
+      "last_heartbeat": "2024-05-01T12:00:00Z",
+      "worker_id": "1234",
+      "worker_name": "test-worker",
+      "version": "v0.0.1"
+    }
+    """;
+
+    [Fact]
+    public void DeserializeSample()
+    {
+        var status = JsonSerializer.Deserialize<WorkerStatus>(SampleJson);
+        Assert.NotNull(status);
+        Assert.Equal(WorkerState.ConnectedIdle, status!.State);
+        Assert.Equal("test-worker", status.WorkerName);
+        Assert.Equal(1, status.CurrentJobs);
+    }
+}

--- a/desktop/windows/TrayApp/StatusClient.cs
+++ b/desktop/windows/TrayApp/StatusClient.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace TrayApp;
+
+public enum WorkerState
+{
+    ConnectedIdle,
+    ConnectedBusy,
+    Connecting,
+    Disconnected,
+    Draining,
+    Terminating,
+    Error,
+}
+
+public class WorkerStateConverter : JsonConverter<WorkerState>
+{
+    public override WorkerState Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var value = reader.GetString();
+        return value switch
+        {
+            "connected_idle" => WorkerState.ConnectedIdle,
+            "connected_busy" => WorkerState.ConnectedBusy,
+            "connecting" => WorkerState.Connecting,
+            "disconnected" => WorkerState.Disconnected,
+            "draining" => WorkerState.Draining,
+            "terminating" => WorkerState.Terminating,
+            "error" => WorkerState.Error,
+            _ => throw new JsonException($"Unknown worker state '{value}'"),
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, WorkerState value, JsonSerializerOptions options)
+    {
+        var str = value switch
+        {
+            WorkerState.ConnectedIdle => "connected_idle",
+            WorkerState.ConnectedBusy => "connected_busy",
+            WorkerState.Connecting => "connecting",
+            WorkerState.Disconnected => "disconnected",
+            WorkerState.Draining => "draining",
+            WorkerState.Terminating => "terminating",
+            WorkerState.Error => "error",
+            _ => throw new JsonException($"Unknown worker state '{value}'"),
+        };
+        writer.WriteStringValue(str);
+    }
+}
+
+public record WorkerStatus(
+    [property: JsonPropertyName("state"), JsonConverter(typeof(WorkerStateConverter))]
+    WorkerState State,
+    [property: JsonPropertyName("connected_to_server")]
+    bool ConnectedToServer,
+    [property: JsonPropertyName("connected_to_ollama")]
+    bool ConnectedToOllama,
+    [property: JsonPropertyName("current_jobs")]
+    int CurrentJobs,
+    [property: JsonPropertyName("max_concurrency")]
+    int MaxConcurrency,
+    [property: JsonPropertyName("models")]
+    string[] Models,
+    [property: JsonPropertyName("last_error")]
+    string LastError,
+    [property: JsonPropertyName("last_heartbeat")]
+    string LastHeartbeat,
+    [property: JsonPropertyName("worker_id")]
+    string WorkerId,
+    [property: JsonPropertyName("worker_name")]
+    string WorkerName,
+    [property: JsonPropertyName("version")]
+    string Version
+);
+
+public class StatusClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly string _url;
+
+    public StatusClient(int port = 4555, HttpClient? httpClient = null)
+    {
+        _httpClient = httpClient ?? new HttpClient();
+        _url = $"http://127.0.0.1:{port}/status";
+    }
+
+    public async Task<WorkerStatus> FetchStatusAsync()
+    {
+        using var stream = await _httpClient.GetStreamAsync(_url);
+        var status = await JsonSerializer.DeserializeAsync<WorkerStatus>(stream);
+        if (status == null)
+        {
+            throw new InvalidOperationException("Unable to deserialize worker status");
+        }
+        return status;
+    }
+}

--- a/desktop/windows/TrayApp/TrayAppContext.cs
+++ b/desktop/windows/TrayApp/TrayAppContext.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Drawing;
+using System.Net.Http;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace TrayApp;
@@ -8,12 +10,23 @@ public class TrayAppContext : ApplicationContext
 {
     private readonly NotifyIcon _notifyIcon;
     private readonly ToolStripMenuItem _statusItem;
+    private readonly ToolStripMenuItem _detailsItem;
     private readonly ToolStripMenuItem _startStopItem;
     private readonly ToolStripMenuItem _startWithWindowsItem;
+
+    private readonly StatusClient _statusClient;
+    private readonly Timer _statusTimer;
+    private WorkerStatus? _currentStatus;
+    private string? _lastError;
 
     public TrayAppContext()
     {
         _statusItem = new ToolStripMenuItem("Status: Unknown")
+        {
+            Enabled = false
+        };
+
+        _detailsItem = new ToolStripMenuItem("Details...", null, OnDetailsClicked)
         {
             Enabled = false
         };
@@ -30,6 +43,7 @@ public class TrayAppContext : ApplicationContext
         contextMenu.Items.AddRange(new ToolStripItem[]
         {
             _statusItem,
+            _detailsItem,
             new ToolStripSeparator(),
             _startStopItem,
             new ToolStripMenuItem("Preferences...", null, OnPreferencesClicked),
@@ -46,6 +60,11 @@ public class TrayAppContext : ApplicationContext
             Visible = true,
             Text = "llamapool"
         };
+
+        _statusClient = new StatusClient();
+        _statusTimer = new Timer { Interval = 2000 };
+        _statusTimer.Tick += async (_, _) => await RefreshStatusAsync();
+        _statusTimer.Start();
     }
 
     private void OnStartStopClicked(object? sender, EventArgs e)
@@ -80,7 +99,70 @@ public class TrayAppContext : ApplicationContext
 
     private void OnExitClicked(object? sender, EventArgs e)
     {
+        _statusTimer.Stop();
         _notifyIcon.Visible = false;
         Application.Exit();
     }
+
+    private async Task RefreshStatusAsync()
+    {
+        try
+        {
+            var status = await _statusClient.FetchStatusAsync();
+            _currentStatus = status;
+            _lastError = string.IsNullOrEmpty(status.LastError) ? null : status.LastError;
+
+            var text = TextForState(status.State);
+            _statusItem.Text = $"Status: {text}";
+            _notifyIcon.Text = $"llamapool - {text}";
+            _detailsItem.Enabled = true;
+        }
+        catch (HttpRequestException ex)
+        {
+            _currentStatus = null;
+            _lastError = ex.Message;
+            _statusItem.Text = "Status: Disconnected";
+            _notifyIcon.Text = "llamapool - Disconnected";
+            _detailsItem.Enabled = !string.IsNullOrEmpty(_lastError);
+        }
+        catch (Exception ex)
+        {
+            _currentStatus = null;
+            _lastError = ex.Message;
+            _statusItem.Text = "Status: Error";
+            _notifyIcon.Text = "llamapool - Error";
+            _detailsItem.Enabled = true;
+        }
+    }
+
+    private void OnDetailsClicked(object? sender, EventArgs e)
+    {
+        if (_currentStatus != null)
+        {
+            var s = _currentStatus;
+            var msg = $"Worker: {s.WorkerName} ({s.WorkerId})\n" +
+                      $"Version: {s.Version}\n" +
+                      $"Connected to server: {s.ConnectedToServer}\n" +
+                      $"Connected to Ollama: {s.ConnectedToOllama}\n" +
+                      $"Jobs: {s.CurrentJobs}/{s.MaxConcurrency}\n" +
+                      $"Last error: {(string.IsNullOrEmpty(s.LastError) ? "<none>" : s.LastError)}";
+            MessageBox.Show(msg, "Worker Details");
+        }
+        else if (!string.IsNullOrEmpty(_lastError))
+        {
+            MessageBox.Show(_lastError, "Worker Error");
+        }
+    }
+
+    private static string TextForState(WorkerState state) => state switch
+    {
+        WorkerState.ConnectedIdle => "Connected",
+        WorkerState.ConnectedBusy => "Busy",
+        WorkerState.Connecting => "Connecting",
+        WorkerState.Disconnected => "Disconnected",
+        WorkerState.Draining => "Draining",
+        WorkerState.Terminating => "Terminating",
+        WorkerState.Error => "Error",
+        _ => "Unknown"
+    };
 }


### PR DESCRIPTION
## Summary
- poll local worker `/status` endpoint and deserialize into a `WorkerStatus` record
- update tray UI and details dialog with connection state and job info
- add unit test ensuring `/status` JSON deserializes correctly

## Testing
- `dotnet test desktop/windows/TrayApp.Tests/TrayApp.Tests.csproj`
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689e4bc64edc832cbbda9981b6a5bb5e