### PR TITLE
feat: add preferences and config handling to macOS app

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A typical deployment looks like this:
 
 ## macOS Menu Bar App
 
-An early-stage macOS menu bar companion lives under `desktop/macos/llamapool/`. It polls `http://127.0.0.1:4555/status` every two seconds to display live worker status and can manage a per-user LaunchAgent to start or stop a local `llamapool-worker` and toggle launching at login.
+An early-stage macOS menu bar companion lives under `desktop/macos/llamapool/`. It polls `http://127.0.0.1:4555/status` every two seconds to display live worker status and can manage a per-user LaunchAgent to start or stop a local `llamapool-worker` and toggle launching at login. A simple preferences window lets you edit worker connection settings which are written to `~/Library/Application Support/Llamapool/worker.yaml`, and the menu offers quick links to open the config and logs folders.
 The app icon is stored as a base64 file (`AppIcon.png.b64`); decode it to `AppIcon.png` before building.
 
 ### Key features

--- a/desktop/macos/llamapool/llamapool.xcodeproj/project.pbxproj
+++ b/desktop/macos/llamapool/llamapool.xcodeproj/project.pbxproj
@@ -12,6 +12,10 @@
     B21ACD2F315B40E38B7B6A6E /* StatusClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EAD688B5AC2497F99047482 /* StatusClientTests.swift */; };
     3C5A9DCC93AC47D2A548BBF1F8E26370 /* LaunchAgentManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F4338ED4FF54C8F9A7491F083790C23 /* LaunchAgentManager.swift */; };
     5D748F4BE7C9450EAD7714010E8AA9F8 /* io.llamapool.worker.plist.template in Resources */ = {isa = PBXBuildFile; fileRef = 911230C1E6D64B889FDC9BC0A8E368F2 /* io.llamapool.worker.plist.template */; };
+    A1B2C3D4E5F60708A9B0C1D2 /* WorkerConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3E4F5A60708B9C0D1E2 /* WorkerConfig.swift */; };
+    C3D4E5F60708A9B0C1D2E3F4 /* ConfigManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E5F60708A9B0C1D2E3F4A5 /* ConfigManager.swift */; };
+    D5E6F708A9B0C1D2E3F4A5B6 /* PreferencesWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5F708A9B0C1D2E3F4A5B6C7 /* PreferencesWindowController.swift */; };
+    F6A7B8C9D0E1F2A3B4C5D6E7 /* ConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7B8C9D0E1F2A3B4C5D6E7F8 /* ConfigTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -24,6 +28,10 @@
     9FDC5B0B495D4A6C8C96F2E9 /* llamapoolTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = llamapoolTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
     6F4338ED4FF54C8F9A7491F083790C23 /* LaunchAgentManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchAgentManager.swift; sourceTree = "<group>"; };
     911230C1E6D64B889FDC9BC0A8E368F2 /* io.llamapool.worker.plist.template */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = io.llamapool.worker.plist.template; sourceTree = "<group>"; };
+    B1C2D3E4F5A60708B9C0D1E2 /* WorkerConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkerConfig.swift; sourceTree = "<group>"; };
+    D4E5F60708A9B0C1D2E3F4A5 /* ConfigManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigManager.swift; sourceTree = "<group>"; };
+    E5F708A9B0C1D2E3F4A5B6C7 /* PreferencesWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesWindowController.swift; sourceTree = "<group>"; };
+    A7B8C9D0E1F2A3B4C5D6E7F8 /* ConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -47,6 +55,9 @@
         9B993A0AF20C45B9BFF02576573C7A4D /* AppDelegate.swift */,
         6F4338ED4FF54C8F9A7491F083790C23 /* LaunchAgentManager.swift */,
         D6F8C39D6E9C4E14A5D0E2D9 /* StatusClient.swift */,
+        B1C2D3E4F5A60708B9C0D1E2 /* WorkerConfig.swift */,
+        D4E5F60708A9B0C1D2E3F4A5 /* ConfigManager.swift */,
+        E5F708A9B0C1D2E3F4A5B6C7 /* PreferencesWindowController.swift */,
         DB20D9050486454BA6F1464F12F231D1 /* Assets.xcassets */,
         24B6B6BC5ECD4E9CA7C7F7E8086B9FA5 /* Info.plist */,
         B3A7F042CB5C4B0891846F5A8C13A01F /* Resources */,
@@ -66,6 +77,7 @@
       isa = PBXGroup;
       children = (
         4EAD688B5AC2497F99047482 /* StatusClientTests.swift */,
+        A7B8C9D0E1F2A3B4C5D6E7F8 /* ConfigTests.swift */,
       );
       path = llamapoolTests;
       sourceTree = "<group>";
@@ -179,6 +191,9 @@
         0CC07EE6BD4045DDAE821661FA6666E4 /* AppDelegate.swift in Sources */,
         4AB0C8F71A2346C8B30B5E02 /* StatusClient.swift in Sources */,
         3C5A9DCC93AC47D2A548BBF1F8E26370 /* LaunchAgentManager.swift in Sources */,
+        A1B2C3D4E5F60708A9B0C1D2 /* WorkerConfig.swift in Sources */,
+        C3D4E5F60708A9B0C1D2E3F4 /* ConfigManager.swift in Sources */,
+        D5E6F708A9B0C1D2E3F4A5B6 /* PreferencesWindowController.swift in Sources */,
       );
       runOnlyForDeploymentPostprocessing = 0;
     };
@@ -187,6 +202,7 @@
       buildActionMask = 2147483647;
       files = (
         B21ACD2F315B40E38B7B6A6E /* StatusClientTests.swift in Sources */,
+        F6A7B8C9D0E1F2A3B4C5D6E7 /* ConfigTests.swift in Sources */,
       );
       runOnlyForDeploymentPostprocessing = 0;
     };

--- a/desktop/macos/llamapool/llamapool/AppDelegate.swift
+++ b/desktop/macos/llamapool/llamapool/AppDelegate.swift
@@ -11,6 +11,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var lastErrorItem: NSMenuItem!
     var statusClient: StatusClient?
     var loginItem: NSMenuItem!
+    var preferencesWindow: PreferencesWindowController?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
@@ -41,7 +42,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         menu.addItem(NSMenuItem(title: "Stop Worker", action: #selector(stopWorker), keyEquivalent: ""))
         menu.addItem(NSMenuItem.separator())
         menu.addItem(NSMenuItem(title: "Preferences…", action: #selector(openPreferences), keyEquivalent: ","))
-        menu.addItem(NSMenuItem(title: "Logs…", action: #selector(openLogs), keyEquivalent: "l"))
+        menu.addItem(NSMenuItem(title: "Open Config Folder", action: #selector(openConfigFolder), keyEquivalent: ""))
+        menu.addItem(NSMenuItem(title: "Open Logs Folder", action: #selector(openLogsFolder), keyEquivalent: ""))
         loginItem = NSMenuItem(title: "Start at Login", action: #selector(toggleStartAtLogin), keyEquivalent: "")
         loginItem.state = LaunchAgentManager.shared.isRunAtLoadEnabled() ? .on : .off
         menu.addItem(loginItem)
@@ -129,11 +131,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc func openPreferences(_ sender: Any?) {
-        print("Preferences clicked")
+        if preferencesWindow == nil {
+            preferencesWindow = PreferencesWindowController()
+        }
+        preferencesWindow?.showWindow(nil)
+        NSApp.activate(ignoringOtherApps: true)
     }
 
-    @objc func openLogs(_ sender: Any?) {
-        print("Logs clicked")
+    @objc func openConfigFolder(_ sender: Any?) {
+        ConfigManager.shared.openConfigFolder()
+    }
+
+    @objc func openLogsFolder(_ sender: Any?) {
+        ConfigManager.shared.openLogsFolder()
     }
 
     @objc func toggleStartAtLogin(_ sender: NSMenuItem) {

--- a/desktop/macos/llamapool/llamapool/ConfigManager.swift
+++ b/desktop/macos/llamapool/llamapool/ConfigManager.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+class ConfigManager {
+    static let shared = ConfigManager()
+    private let fileManager = FileManager.default
+    private init() {}
+
+    private var configDirURL: URL {
+        fileManager.homeDirectoryForCurrentUser.appendingPathComponent("Library/Application Support/Llamapool", isDirectory: true)
+    }
+
+    private var configFileURL: URL {
+        configDirURL.appendingPathComponent("worker.yaml")
+    }
+
+    func load() -> WorkerConfig {
+        guard let data = try? String(contentsOf: configFileURL) else {
+            return WorkerConfig()
+        }
+        return WorkerConfig.fromYAML(data)
+    }
+
+    func save(_ config: WorkerConfig) throws {
+        try fileManager.createDirectory(at: configDirURL, withIntermediateDirectories: true)
+        let yaml = config.toYAML()
+        try yaml.write(to: configFileURL, atomically: true, encoding: .utf8)
+    }
+
+    func openConfigFolder() {
+        NSWorkspace.shared.open(configDirURL)
+    }
+
+    func openLogsFolder() {
+        let logsURL = fileManager.homeDirectoryForCurrentUser.appendingPathComponent("Library/Logs/Llamapool", isDirectory: true)
+        NSWorkspace.shared.open(logsURL)
+    }
+}

--- a/desktop/macos/llamapool/llamapool/LaunchAgentManager.swift
+++ b/desktop/macos/llamapool/llamapool/LaunchAgentManager.swift
@@ -54,6 +54,14 @@ class LaunchAgentManager {
         return false
     }
 
+    func configDirectory() -> URL {
+        configDirURL
+    }
+
+    func logsDirectory() -> URL {
+        logsDirURL
+    }
+
     func isAgentLoaded() -> Bool {
         (try? runLaunchctl(["list", label]).exitCode) == 0
     }

--- a/desktop/macos/llamapool/llamapool/PreferencesWindowController.swift
+++ b/desktop/macos/llamapool/llamapool/PreferencesWindowController.swift
@@ -1,0 +1,89 @@
+import Cocoa
+
+class PreferencesWindowController: NSWindowController {
+    private let form = NSForm(frame: NSRect(x: 20, y: 60, width: 360, height: 140))
+    private var serverEntry: NSFormCell!
+    private var keyEntry: NSFormCell!
+    private var ollamaEntry: NSFormCell!
+    private var concurrencyEntry: NSFormCell!
+    private var portEntry: NSFormCell!
+
+    init() {
+        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 400, height: 250),
+                              styleMask: [.titled, .closable],
+                              backing: .buffered, defer: false)
+        window.center()
+        window.title = "Preferences"
+        super.init(window: window)
+
+        serverEntry = form.addEntry("Server URL:")
+        keyEntry = form.addEntry("Worker Key:")
+        ollamaEntry = form.addEntry("Ollama Base URL:")
+        concurrencyEntry = form.addEntry("Max Concurrency:")
+        portEntry = form.addEntry("Status Port:")
+        window.contentView?.addSubview(form)
+
+        let saveButton = NSButton(title: "Save", target: self, action: #selector(save))
+        saveButton.frame = NSRect(x: 220, y: 20, width: 80, height: 30)
+        let cancelButton = NSButton(title: "Cancel", target: self, action: #selector(cancel))
+        cancelButton.frame = NSRect(x: 310, y: 20, width: 80, height: 30)
+        window.contentView?.addSubview(saveButton)
+        window.contentView?.addSubview(cancelButton)
+
+        let config = ConfigManager.shared.load()
+        serverEntry.stringValue = config.serverURL
+        keyEntry.stringValue = config.workerKey
+        ollamaEntry.stringValue = config.ollamaBaseURL
+        concurrencyEntry.stringValue = String(config.maxConcurrency)
+        portEntry.stringValue = String(config.statusPort)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    @objc private func save() {
+        guard !serverEntry.stringValue.isEmpty,
+              let maxConc = Int(concurrencyEntry.stringValue),
+              let port = Int(portEntry.stringValue) else {
+            let alert = NSAlert()
+            alert.messageText = "Invalid input"
+            alert.runModal()
+            return
+        }
+        let config = WorkerConfig(serverURL: serverEntry.stringValue,
+                                  workerKey: keyEntry.stringValue,
+                                  ollamaBaseURL: ollamaEntry.stringValue,
+                                  maxConcurrency: maxConc,
+                                  statusPort: port)
+        guard config.isValid() else {
+            let alert = NSAlert()
+            alert.messageText = "Invalid configuration"
+            alert.runModal()
+            return
+        }
+        do {
+            try ConfigManager.shared.save(config)
+        } catch {
+            let alert = NSAlert(error: error)
+            alert.runModal()
+            return
+        }
+        if LaunchAgentManager.shared.isAgentLoaded() {
+            let alert = NSAlert()
+            alert.messageText = "Restart worker to apply changes?"
+            alert.addButton(withTitle: "Restart")
+            alert.addButton(withTitle: "Later")
+            let response = alert.runModal()
+            if response == .alertFirstButtonReturn {
+                try? LaunchAgentManager.shared.stop()
+                try? LaunchAgentManager.shared.start()
+            }
+        }
+        window?.close()
+    }
+
+    @objc private func cancel() {
+        window?.close()
+    }
+}

--- a/desktop/macos/llamapool/llamapool/WorkerConfig.swift
+++ b/desktop/macos/llamapool/llamapool/WorkerConfig.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+struct WorkerConfig: Equatable {
+    var serverURL: String
+    var workerKey: String
+    var ollamaBaseURL: String
+    var maxConcurrency: Int
+    var statusPort: Int
+
+    init(serverURL: String = "", workerKey: String = "", ollamaBaseURL: String = "", maxConcurrency: Int = 1, statusPort: Int = 4555) {
+        self.serverURL = serverURL
+        self.workerKey = workerKey
+        self.ollamaBaseURL = ollamaBaseURL
+        self.maxConcurrency = maxConcurrency
+        self.statusPort = statusPort
+    }
+
+    func toYAML() -> String {
+        return """
+server_url: \(serverURL)
+worker_key: \(workerKey)
+ollama_base_url: \(ollamaBaseURL)
+max_concurrency: \(maxConcurrency)
+status_port: \(statusPort)
+"""
+    }
+
+    static func fromYAML(_ yaml: String) -> WorkerConfig {
+        var dict: [String: String] = [:]
+        yaml.split(separator: "\n").forEach { line in
+            let parts = line.split(separator: ":", maxSplits: 1).map { String($0).trimmingCharacters(in: .whitespaces) }
+            if parts.count == 2 {
+                dict[parts[0]] = parts[1]
+            }
+        }
+        let serverURL = dict["server_url"] ?? ""
+        let workerKey = dict["worker_key"] ?? ""
+        let ollamaBaseURL = dict["ollama_base_url"] ?? ""
+        let maxConcurrency = Int(dict["max_concurrency"] ?? "1") ?? 1
+        let statusPort = Int(dict["status_port"] ?? "4555") ?? 4555
+        return WorkerConfig(serverURL: serverURL, workerKey: workerKey, ollamaBaseURL: ollamaBaseURL, maxConcurrency: maxConcurrency, statusPort: statusPort)
+    }
+
+    func isValid() -> Bool {
+        return !serverURL.isEmpty && maxConcurrency > 0 && statusPort > 0
+    }
+}

--- a/desktop/macos/llamapool/llamapoolTests/ConfigTests.swift
+++ b/desktop/macos/llamapool/llamapoolTests/ConfigTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import llamapool
+
+final class ConfigTests: XCTestCase {
+    func testYAMLRoundTrip() throws {
+        let config = WorkerConfig(serverURL: "wss://example", workerKey: "key", ollamaBaseURL: "http://localhost", maxConcurrency: 2, statusPort: 4555)
+        let yaml = config.toYAML()
+        let decoded = WorkerConfig.fromYAML(yaml)
+        XCTAssertEqual(config, decoded)
+    }
+
+    func testValidationFailsOnEmptyServer() {
+        let config = WorkerConfig()
+        XCTAssertFalse(config.isValid())
+    }
+}


### PR DESCRIPTION
## Summary
- add preferences window with fields for worker configuration and restart prompt
- persist worker settings as YAML and expose menu shortcuts to open config and logs folders
- cover config parsing and validation with unit tests

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689e596a8eb0832cb680d1c3f2c5698b