### PR TITLE
worker: add optional reconnect on server failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ go run .\cmd\llamapool-worker
 .\bin\llamapool-worker.exe
 ```
 
+By default the worker exits if the server is unavailable. Add `-r` or `--reconnect` to keep retrying with backoff (1s×3, 5s×3, 15s×3, then every 30s).
+
 
 
 ## Run with Docker

--- a/internal/config/worker.go
+++ b/internal/config/worker.go
@@ -26,6 +26,7 @@ type WorkerConfig struct {
 	DrainTimeout   time.Duration
 	ConfigFile     string
 	LogDir         string
+	Reconnect      bool
 }
 
 func (c *WorkerConfig) BindFlags() {
@@ -58,6 +59,9 @@ func (c *WorkerConfig) BindFlags() {
 		host = "worker-" + uuid.NewString()[:8]
 	}
 	c.WorkerName = getEnv("WORKER_NAME", host)
+	if b, err := strconv.ParseBool(getEnv("RECONNECT", "false")); err == nil {
+		c.Reconnect = b
+	}
 
 	flag.StringVar(&c.ServerURL, "server-url", c.ServerURL, "server websocket url")
 	flag.StringVar(&c.WorkerKey, "worker-key", c.WorkerKey, "worker auth key")
@@ -71,6 +75,8 @@ func (c *WorkerConfig) BindFlags() {
 	flag.StringVar(&c.ConfigFile, "config", c.ConfigFile, "worker config file path")
 	flag.StringVar(&c.LogDir, "log-dir", c.LogDir, "log directory")
 	flag.DurationVar(&c.DrainTimeout, "drain-timeout", c.DrainTimeout, "time to wait for in-flight jobs on shutdown (-1 to wait indefinitely, 0 to exit immediately)")
+	flag.BoolVar(&c.Reconnect, "reconnect", c.Reconnect, "reconnect to server on failure")
+	flag.BoolVar(&c.Reconnect, "r", c.Reconnect, "short for --reconnect")
 }
 
 func defaultWorkerPaths() (configFile, logDir string) {

--- a/internal/worker/reconnect_test.go
+++ b/internal/worker/reconnect_test.go
@@ -1,0 +1,13 @@
+package worker
+
+import "testing"
+
+func TestReconnectDelay(t *testing.T) {
+	expected := []int{1, 1, 1, 5, 5, 5, 15, 15, 15, 30, 30}
+	for i, exp := range expected {
+		d := reconnectDelay(i)
+		if int(d.Seconds()) != exp {
+			t.Errorf("attempt %d: expected %d got %v", i, exp, d)
+		}
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -52,10 +52,36 @@ func Run(ctx context.Context, cfg config.WorkerConfig) error {
 		}
 	}
 
-	ws, _, err := websocket.Dial(ctx, cfg.ServerURL, nil)
+	attempt := 0
+	for {
+		SetState("connecting")
+		SetConnectedToServer(false)
+		connected, err := connectAndServe(ctx, cfg, client)
+		if err == nil || !cfg.Reconnect {
+			return err
+		}
+		if connected {
+			attempt = 0
+		}
+		delay := reconnectDelay(attempt)
+		attempt++
+		logx.Log.Warn().Dur("backoff", delay).Err(err).Msg("connection to server lost; retrying")
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(delay):
+		}
+	}
+}
+
+func connectAndServe(ctx context.Context, cfg config.WorkerConfig, client *ollama.Client) (bool, error) {
+	connCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	ws, _, err := websocket.Dial(connCtx, cfg.ServerURL, nil)
 	if err != nil {
 		SetLastError(err.Error())
-		return err
+		SetState("error")
+		return false, err
 	}
 	defer func() {
 		_ = ws.Close(websocket.StatusInternalError, "closing")
@@ -66,25 +92,28 @@ func Run(ctx context.Context, cfg config.WorkerConfig) error {
 	SetLastError("")
 
 	sendCh := make(chan []byte, 16)
+	defer close(sendCh)
 	reqCancels := make(map[string]context.CancelFunc)
 	var jobMu sync.Mutex
 	go func() {
+		defer cancel()
 		for msg := range sendCh {
-			if err := ws.Write(ctx, websocket.MessageText, msg); err != nil {
+			if err := ws.Write(connCtx, websocket.MessageText, msg); err != nil {
 				return
 			}
 		}
 	}()
 
-	regMsg := ctrl.RegisterMessage{Type: "register", WorkerID: cfg.WorkerID, WorkerName: cfg.WorkerName, WorkerKey: cfg.WorkerKey, Models: models, MaxConcurrency: cfg.MaxConcurrency}
+	regMsg := ctrl.RegisterMessage{Type: "register", WorkerID: cfg.WorkerID, WorkerName: cfg.WorkerName, WorkerKey: cfg.WorkerKey, Models: GetState().Models, MaxConcurrency: cfg.MaxConcurrency}
 	b, _ := json.Marshal(regMsg)
 	sendCh <- b
 
 	go func() {
 		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
 		for {
 			select {
-			case <-ctx.Done():
+			case <-connCtx.Done():
 				return
 			case t := <-ticker.C:
 				hb := ctrl.HeartbeatMessage{Type: "heartbeat", TS: t.Unix()}
@@ -104,15 +133,15 @@ func Run(ctx context.Context, cfg config.WorkerConfig) error {
 	}
 
 	for {
-		_, data, err := ws.Read(ctx)
+		_, data, err := ws.Read(connCtx)
 		if err != nil {
 			SetConnectedToServer(false)
 			if IsDraining() {
-				return nil
+				return true, nil
 			}
 			SetLastError(err.Error())
 			SetState("error")
-			return err
+			return true, err
 		}
 		var env struct {
 			Type string `json:"type"`
@@ -134,7 +163,7 @@ func Run(ctx context.Context, cfg config.WorkerConfig) error {
 				continue
 			}
 			if jr.Endpoint == "generate" {
-				go handleGenerate(ctx, client, sendCh, jr, reqCancels, &jobMu, checkDrain)
+				go handleGenerate(connCtx, client, sendCh, jr, reqCancels, &jobMu, checkDrain)
 			}
 		case "cancel_job":
 			var cj ctrl.CancelJobMessage
@@ -161,7 +190,7 @@ func Run(ctx context.Context, cfg config.WorkerConfig) error {
 				sendCh <- eb
 				continue
 			}
-			go handleHTTPProxy(ctx, cfg, sendCh, hr, reqCancels, &jobMu, checkDrain)
+			go handleHTTPProxy(connCtx, cfg, sendCh, hr, reqCancels, &jobMu, checkDrain)
 		case "http_proxy_cancel":
 			var hc ctrl.HTTPProxyCancelMessage
 			if err := json.Unmarshal(data, &hc); err == nil {
@@ -174,6 +203,14 @@ func Run(ctx context.Context, cfg config.WorkerConfig) error {
 			}
 		}
 	}
+}
+
+func reconnectDelay(attempt int) time.Duration {
+	schedule := []time.Duration{time.Second, time.Second, time.Second, 5 * time.Second, 5 * time.Second, 5 * time.Second, 15 * time.Second, 15 * time.Second, 15 * time.Second}
+	if attempt < len(schedule) {
+		return schedule[attempt]
+	}
+	return 30 * time.Second
 }
 
 type healthClient interface {


### PR DESCRIPTION
## Summary
- add `-r/--reconnect` flag for workers
- retry server connection with progressive backoff
- document reconnect option and cover delay sequence in tests

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689e737cc6cc832c96dc5c61eebcf1a0