### PR TITLE
Add log viewer and diagnostics copy for macOS app

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A typical deployment looks like this:
 
 ## macOS Menu Bar App
 
-An early-stage macOS menu bar companion lives under `desktop/macos/llamapool/`. It polls `http://127.0.0.1:4555/status` every two seconds to display live worker status and can manage a per-user LaunchAgent to start or stop a local `llamapool-worker` and toggle launching at login. A simple preferences window lets you edit worker connection settings which are written to `~/Library/Application Support/Llamapool/worker.yaml`, and the menu offers quick links to open the config and logs folders.
+An early-stage macOS menu bar companion lives under `desktop/macos/llamapool/`. It polls `http://127.0.0.1:4555/status` every two seconds to display live worker status and can manage a per-user LaunchAgent to start or stop a local `llamapool-worker` and toggle launching at login. A simple preferences window lets you edit worker connection settings which are written to `~/Library/Application Support/Llamapool/worker.yaml`, and the menu offers quick links to open the config and logs folders, view live logs, and copy diagnostics to the Desktop.
 
 ## Windows Tray App
 

--- a/desktop/macos/llamapool/llamapool.xcodeproj/project.pbxproj
+++ b/desktop/macos/llamapool/llamapool.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
     C3D4E5F60708A9B0C1D2E3F4 /* ConfigManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E5F60708A9B0C1D2E3F4A5 /* ConfigManager.swift */; };
     D5E6F708A9B0C1D2E3F4A5B6 /* PreferencesWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5F708A9B0C1D2E3F4A5B6C7 /* PreferencesWindowController.swift */; };
     F6A7B8C9D0E1F2A3B4C5D6E7 /* ConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7B8C9D0E1F2A3B4C5D6E7F8 /* ConfigTests.swift */; };
+    F87D63A5663A4EE58D6FCAF1B3361D33 /* LogsWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 971B6CAEA8F64FC59C9EB4D41F6B6685 /* LogsWindowController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -32,6 +33,7 @@
     D4E5F60708A9B0C1D2E3F4A5 /* ConfigManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigManager.swift; sourceTree = "<group>"; };
     E5F708A9B0C1D2E3F4A5B6C7 /* PreferencesWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesWindowController.swift; sourceTree = "<group>"; };
     A7B8C9D0E1F2A3B4C5D6E7F8 /* ConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigTests.swift; sourceTree = "<group>"; };
+    971B6CAEA8F64FC59C9EB4D41F6B6685 /* LogsWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogsWindowController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -58,6 +60,7 @@
         B1C2D3E4F5A60708B9C0D1E2 /* WorkerConfig.swift */,
         D4E5F60708A9B0C1D2E3F4A5 /* ConfigManager.swift */,
         E5F708A9B0C1D2E3F4A5B6C7 /* PreferencesWindowController.swift */,
+        971B6CAEA8F64FC59C9EB4D41F6B6685 /* LogsWindowController.swift */,
         DB20D9050486454BA6F1464F12F231D1 /* Assets.xcassets */,
         24B6B6BC5ECD4E9CA7C7F7E8086B9FA5 /* Info.plist */,
         B3A7F042CB5C4B0891846F5A8C13A01F /* Resources */,
@@ -194,6 +197,7 @@
         A1B2C3D4E5F60708A9B0C1D2 /* WorkerConfig.swift in Sources */,
         C3D4E5F60708A9B0C1D2E3F4 /* ConfigManager.swift in Sources */,
         D5E6F708A9B0C1D2E3F4A5B6 /* PreferencesWindowController.swift in Sources */,
+        F87D63A5663A4EE58D6FCAF1B3361D33 /* LogsWindowController.swift in Sources */,
       );
       runOnlyForDeploymentPostprocessing = 0;
     };

--- a/desktop/macos/llamapool/llamapool/AppDelegate.swift
+++ b/desktop/macos/llamapool/llamapool/AppDelegate.swift
@@ -13,6 +13,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var controlClient: ControlClient?
     var loginItem: NSMenuItem!
     var preferencesWindow: PreferencesWindowController?
+    var logsWindow: LogsWindowController?
     var startWorkerItem: NSMenuItem!
     var stopWorkerItem: NSMenuItem!
     var drainItem: NSMenuItem!
@@ -59,6 +60,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         menu.addItem(shutdownItem)
         menu.addItem(NSMenuItem.separator())
         menu.addItem(NSMenuItem(title: "Preferences…", action: #selector(openPreferences), keyEquivalent: ","))
+        menu.addItem(NSMenuItem(title: "Logs…", action: #selector(openLogs), keyEquivalent: ""))
+        menu.addItem(NSMenuItem(title: "Copy Diagnostics", action: #selector(copyDiagnostics), keyEquivalent: ""))
         menu.addItem(NSMenuItem(title: "Open Config Folder", action: #selector(openConfigFolder), keyEquivalent: ""))
         menu.addItem(NSMenuItem(title: "Open Logs Folder", action: #selector(openLogsFolder), keyEquivalent: ""))
         loginItem = NSMenuItem(title: "Start at Login", action: #selector(toggleStartAtLogin), keyEquivalent: "")
@@ -178,6 +181,27 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc func openLogsFolder(_ sender: Any?) {
         ConfigManager.shared.openLogsFolder()
+    }
+
+    @objc func openLogs(_ sender: Any?) {
+        if logsWindow == nil {
+            logsWindow = LogsWindowController()
+        }
+        logsWindow?.showWindow(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    @objc func copyDiagnostics(_ sender: Any?) {
+        do {
+            let url = try ConfigManager.shared.copyDiagnostics()
+            let alert = NSAlert()
+            alert.messageText = "Diagnostics copied to Desktop"
+            alert.informativeText = url.path
+            alert.runModal()
+        } catch {
+            let alert = NSAlert(error: error)
+            alert.runModal()
+        }
     }
 
     @objc func toggleStartAtLogin(_ sender: NSMenuItem) {

--- a/desktop/macos/llamapool/llamapool/LogsWindowController.swift
+++ b/desktop/macos/llamapool/llamapool/LogsWindowController.swift
@@ -1,0 +1,75 @@
+import Cocoa
+
+class LogsWindowController: NSWindowController {
+    private let outTextView = NSTextView()
+    private let errTextView = NSTextView()
+    private var outHandle: FileHandle?
+    private var errHandle: FileHandle?
+    private var outSource: DispatchSourceFileSystemObject?
+    private var errSource: DispatchSourceFileSystemObject?
+
+    init() {
+        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 600, height: 400),
+                              styleMask: [.titled, .closable, .resizable],
+                              backing: .buffered, defer: false)
+        window.title = "Worker Logs"
+        let split = NSSplitView(frame: window.contentView!.bounds)
+        split.isVertical = false
+        split.autoresizingMask = [.width, .height]
+        let outScroll = NSScrollView()
+        outScroll.hasVerticalScroller = true
+        outScroll.documentView = outTextView
+        outTextView.isEditable = false
+        let errScroll = NSScrollView()
+        errScroll.hasVerticalScroller = true
+        errScroll.documentView = errTextView
+        errTextView.isEditable = false
+        split.addArrangedSubview(outScroll)
+        split.addArrangedSubview(errScroll)
+        window.contentView?.addSubview(split)
+        super.init(window: window)
+        tailLogs()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func tailLogs() {
+        tail(file: ConfigManager.shared.logsDirURL.appendingPathComponent("worker.out"),
+             textView: outTextView,
+             handle: &outHandle,
+             source: &outSource)
+        tail(file: ConfigManager.shared.logsDirURL.appendingPathComponent("worker.err"),
+             textView: errTextView,
+             handle: &errHandle,
+             source: &errSource)
+    }
+
+    private func tail(file: URL, textView: NSTextView, handle: inout FileHandle?, source: inout DispatchSourceFileSystemObject?) {
+        guard FileManager.default.fileExists(atPath: file.path),
+              let fh = try? FileHandle(forReadingFrom: file) else { return }
+        handle = fh
+        fh.seekToEndOfFile()
+        source = DispatchSource.makeFileSystemObjectSource(fileDescriptor: fh.fileDescriptor,
+                                                            eventMask: .extend,
+                                                            queue: DispatchQueue.global())
+        source?.setEventHandler {
+            let data = fh.readDataToEndOfFile()
+            if let str = String(data: data, encoding: .utf8) {
+                DispatchQueue.main.async {
+                    textView.string += str
+                    textView.scrollToEndOfDocument(nil)
+                }
+            }
+        }
+        source?.resume()
+    }
+
+    deinit {
+        outSource?.cancel()
+        errSource?.cancel()
+        try? outHandle?.close()
+        try? errHandle?.close()
+    }
+}


### PR DESCRIPTION
## Summary
- add simple tail-based log viewer for worker stdout/stderr
- allow copying diagnostics (logs, config, launch agent) to a zip on Desktop
- document new macOS menu bar features

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689ea7a23b20832caaa74edaac51bc26