### PR TITLE
Add swagger OpenAPI endpoint for client docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ The tray can start or stop the local `llamapool` Windows service, toggle whether
   - **State (JSON):** `GET /api/v1/state`
   - **State (SSE):** `GET /api/v1/state/stream`
 - Prometheus metrics: `GET /metrics` (can run on a separate port via `--metrics-port`)
+- API docs:
+  - Swagger UI: `GET /api/client/`
+  - OpenAPI schema: `GET /api/client/openapi.json`
 
 
 ## Security

--- a/internal/api/openapi.go
+++ b/internal/api/openapi.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	_ "embed"
+	"net/http"
+
+	"github.com/you/llamapool/internal/logx"
+)
+
+//go:embed openapi.json
+var openapiJSON []byte
+
+// OpenAPIHandler serves the embedded OpenAPI schema.
+func OpenAPIHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write(openapiJSON); err != nil {
+			// ignore error but log
+			logx.Log.Error().Err(err).Msg("write openapi")
+		}
+	}
+}
+
+const swaggerPage = `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>llamapool API</title>
+  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css" />
+</head>
+<body>
+  <div id="swagger-ui"></div>
+  <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+  <script>
+  window.onload = () => {
+    SwaggerUIBundle({
+      url: 'openapi.json',
+      dom_id: '#swagger-ui'
+    });
+  };
+  </script>
+</body>
+</html>`
+
+// SwaggerHandler serves a minimal Swagger UI.
+func SwaggerHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if _, err := w.Write([]byte(swaggerPage)); err != nil {
+			// ignore error but log
+			logx.Log.Error().Err(err).Msg("write swagger page")
+		}
+	}
+}

--- a/internal/api/openapi.json
+++ b/internal/api/openapi.json
@@ -1,0 +1,83 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "llamapool API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/api/generate": {
+      "post": {
+        "summary": "Generate content",
+        "responses": {
+          "200": {
+            "description": "Generated response"
+          }
+        }
+      }
+    },
+    "/api/tags": {
+      "get": {
+        "summary": "List models",
+        "responses": {
+          "200": {"description": "List of models"}
+        }
+      }
+    },
+    "/api/v1/state": {
+      "get": {
+        "summary": "Get server state",
+        "responses": {
+          "200": {"description": "State"}
+        }
+      }
+    },
+    "/api/v1/state/stream": {
+      "get": {
+        "summary": "Stream server state",
+        "responses": {
+          "200": {"description": "Event stream"}
+        }
+      }
+    },
+    "/v1/models": {
+      "get": {
+        "summary": "List models",
+        "responses": {
+          "200": {"description": "OK"}
+        }
+      }
+    },
+    "/v1/models/{id}": {
+      "get": {
+        "summary": "Get model",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {"type": "string"}
+          }
+        ],
+        "responses": {
+          "200": {"description": "OK"}
+        }
+      }
+    },
+    "/v1/chat/completions": {
+      "post": {
+        "summary": "Chat completions",
+        "responses": {
+          "200": {"description": "OK"}
+        }
+      }
+    },
+    "/healthz": {
+      "get": {
+        "summary": "Health check",
+        "responses": {
+          "200": {"description": "OK"}
+        }
+      }
+    }
+  }
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -20,6 +20,10 @@ func New(reg *ctrl.Registry, metrics *ctrl.MetricsRegistry, sched ctrl.Scheduler
 		if cfg.APIKey != "" {
 			r.Use(api.APIKeyMiddleware(cfg.APIKey))
 		}
+		r.Route("/client", func(r chi.Router) {
+			r.Get("/openapi.json", api.OpenAPIHandler())
+			r.Get("/*", api.SwaggerHandler())
+		})
 		r.Mount("/", api.NewRouter(reg, metrics, sched, cfg.RequestTimeout))
 	})
 	r.Route("/v1", func(r chi.Router) {


### PR DESCRIPTION
## Summary
- serve embedded OpenAPI schema at `/api/client/openapi.json`
- add minimal Swagger UI at `/api/client/`
- document new API docs endpoints in README

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689eaf9e31c4832c8ce0a30dfd298953