### PR TITLE
feat(tray): add auto-update support with Squirrel

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,7 @@ The service wrapper launches `llamapool-worker.exe` installed at
 `llamapool` with delayed automatic start. The tray app now polls the local worker
 every two seconds and updates its menu and tooltip to reflect the current status.
 A details dialog shows connection information, job counts, and any last error. A preferences window can edit the worker configuration and write it back to the YAML file, and the menu offers quick links to open the config and logs folders, view live logs, and collect diagnostics.
+The tray app also supports automatic updates via Squirrel.Windows.
 
 ## Currently Supported
 

--- a/desktop/windows/TrayApp/TrayApp.csproj
+++ b/desktop/windows/TrayApp/TrayApp.csproj
@@ -9,5 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="YamlDotNet" Version="13.7.1" />
+    <PackageReference Include="Squirrel.Windows" Version="2.0.1" />
   </ItemGroup>
 </Project>

--- a/desktop/windows/TrayApp/TrayAppContext.cs
+++ b/desktop/windows/TrayApp/TrayAppContext.cs
@@ -4,9 +4,11 @@ using System.Drawing;
 using System.Net.Http;
 using System.IO;
 using System.IO.Compression;
+using System.Linq;
 using System.ServiceProcess;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using Squirrel;
 
 namespace TrayApp;
 
@@ -28,6 +30,7 @@ public class TrayAppContext : ApplicationContext
     private string? _lastError;
     private WorkerConfig _config;
     private bool _controlsAvailable;
+    private const string UpdateRepo = "gaspardpetit/llamapool";
 
     private const string ServiceName = "llamapool";
 
@@ -103,6 +106,7 @@ public class TrayAppContext : ApplicationContext
         _ = ProbeControlEndpointsAsync();
 
         RefreshServiceState();
+        _ = CheckForUpdatesAsync();
     }
 
     private void OnStartStopClicked(object? sender, EventArgs e)
@@ -313,10 +317,37 @@ public class TrayAppContext : ApplicationContext
         }
     }
 
-    private void OnCheckForUpdatesClicked(object? sender, EventArgs e)
+    private async void OnCheckForUpdatesClicked(object? sender, EventArgs e)
     {
-        // TODO: Check for application updates
-        MessageBox.Show("Check for Updates clicked");
+        await CheckForUpdatesAsync(true);
+    }
+
+    private async Task CheckForUpdatesAsync(bool userInitiated = false)
+    {
+        try
+        {
+            using var mgr = await UpdateManager.GitHubUpdateManager(UpdateRepo);
+            var updates = await mgr.CheckForUpdate();
+            if (updates.ReleasesToApply.Any())
+            {
+                await mgr.UpdateApp();
+                if (userInitiated)
+                {
+                    MessageBox.Show("Update installed. Please restart the application.", "Update", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                }
+            }
+            else if (userInitiated)
+            {
+                MessageBox.Show("No updates available.", "Update", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
+        }
+        catch (Exception ex)
+        {
+            if (userInitiated)
+            {
+                MessageBox.Show($"Failed to check for updates: {ex.Message}", "Update", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
     }
 
     private void OnExitClicked(object? sender, EventArgs e)


### PR DESCRIPTION
## Summary
- add Squirrel.Windows package to tray app
- check GitHub for tray updates on startup and via menu item
- document Windows tray auto-update capability

## Testing
- `make lint`
- `make build`
- `make test`
- `dotnet build desktop/windows/Llamapool.Windows.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*
- `dotnet test desktop/windows/Llamapool.Windows.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_689eb81cd774832c92e1be6f6ff8f554