### PR TITLE
ci: add macOS build workflow

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,31 @@
+name: macOS Build
+on:
+  push:
+    branches: [ main ]
+  release:
+    types: [ published ]
+jobs:
+  build:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build (Release)
+        run: |
+          xcodebuild -project desktop/macos/llamapool/llamapool.xcodeproj -scheme llamapool -configuration Release -archivePath build/llamapool.xcarchive archive
+          xcodebuild -exportArchive -archivePath build/llamapool.xcarchive -exportOptionsPlist ci/exportOptions.plist -exportPath build/export
+      - name: Create DMG
+        run: |
+          ci/create-dmg.sh build/export/llamapool.app build/Llamapool.dmg
+      - name: Notarize
+        env:
+          AC_API_KEY_ID: ${{ secrets.AC_API_KEY_ID }}
+          AC_API_ISSUER_ID: ${{ secrets.AC_API_ISSUER_ID }}
+          AC_API_P8: ${{ secrets.AC_API_P8 }}
+        run: ci/notarize.sh build/Llamapool.dmg
+      - name: Staple
+        run: xcrun stapler staple build/Llamapool.dmg
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Llamapool-macOS
+          path: build/Llamapool.dmg

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Build](https://github.com/gaspardpetit/llamapool/actions/workflows/ci.yml/badge.svg)](https://github.com/gaspardpetit/llamapool/actions/workflows/ci.yml)
 [![Docker](https://github.com/gaspardpetit/llamapool/actions/workflows/docker-publish.yml/badge.svg)](https://github.com/gaspardpetit/llamapool/actions/workflows/docker-publish.yml)
 [![.deb](https://github.com/gaspardpetit/llamapool/actions/workflows/release-deb.yml/badge.svg)](https://github.com/gaspardpetit/llamapool/actions/workflows/release-deb.yml)
+[![macOS Build](https://github.com/gaspardpetit/llamapool/actions/workflows/macos.yml/badge.svg)](https://github.com/gaspardpetit/llamapool/actions/workflows/macos.yml)
 
 
 # llamapool

--- a/ci/exportOptions.plist
+++ b/ci/exportOptions.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>method</key>
+  <string>developer-id</string>
+  <key>signingStyle</key>
+  <string>manual</string>
+  <key>stripSwiftSymbols</key>
+  <true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and notarize macOS menu bar app
- provide export options plist for Developer ID archives
- document macOS build workflow with status badge

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689ebf15e834832cabb01aaaa8a69bc5