### PR TITLE
Fix module path and imports

### DIFF
--- a/cmd/llamapool-server/main.go
+++ b/cmd/llamapool-server/main.go
@@ -14,11 +14,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
-	"github.com/you/llamapool/internal/config"
-	"github.com/you/llamapool/internal/ctrl"
-	"github.com/you/llamapool/internal/logx"
-	"github.com/you/llamapool/internal/metrics"
-	"github.com/you/llamapool/internal/server"
+	"github.com/gaspardpetit/llamapool/internal/config"
+	"github.com/gaspardpetit/llamapool/internal/ctrl"
+	"github.com/gaspardpetit/llamapool/internal/logx"
+	"github.com/gaspardpetit/llamapool/internal/metrics"
+	"github.com/gaspardpetit/llamapool/internal/server"
 )
 
 var (

--- a/cmd/llamapool-worker/main.go
+++ b/cmd/llamapool-worker/main.go
@@ -11,9 +11,9 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/you/llamapool/internal/config"
-	"github.com/you/llamapool/internal/logx"
-	"github.com/you/llamapool/internal/worker"
+	"github.com/gaspardpetit/llamapool/internal/config"
+	"github.com/gaspardpetit/llamapool/internal/logx"
+	"github.com/gaspardpetit/llamapool/internal/worker"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/you/llamapool
+module github.com/gaspardpetit/llamapool
 
 go 1.23.0
 

--- a/internal/api/chat_completions.go
+++ b/internal/api/chat_completions.go
@@ -10,8 +10,8 @@ import (
 	chiMiddleware "github.com/go-chi/chi/v5/middleware"
 	"github.com/google/uuid"
 
-	"github.com/you/llamapool/internal/ctrl"
-	"github.com/you/llamapool/internal/logx"
+	"github.com/gaspardpetit/llamapool/internal/ctrl"
+	"github.com/gaspardpetit/llamapool/internal/logx"
 )
 
 // ChatCompletionsHandler handles POST /v1/chat/completions as a pass-through.

--- a/internal/api/chat_completions_test.go
+++ b/internal/api/chat_completions_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/you/llamapool/internal/ctrl"
+	"github.com/gaspardpetit/llamapool/internal/ctrl"
 )
 
 type flushRecorder struct {

--- a/internal/api/docs.go
+++ b/internal/api/docs.go
@@ -3,8 +3,8 @@ package api
 import (
 	"net/http"
 
-	"github.com/you/llamapool/api/generated"
-	"github.com/you/llamapool/internal/logx"
+	"github.com/gaspardpetit/llamapool/api/generated"
+	"github.com/gaspardpetit/llamapool/internal/logx"
 )
 
 var openapiJSON []byte

--- a/internal/api/generate.go
+++ b/internal/api/generate.go
@@ -7,9 +7,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/you/llamapool/internal/ctrl"
-	"github.com/you/llamapool/internal/logx"
-	"github.com/you/llamapool/internal/relay"
+	"github.com/gaspardpetit/llamapool/internal/ctrl"
+	"github.com/gaspardpetit/llamapool/internal/logx"
+	"github.com/gaspardpetit/llamapool/internal/relay"
 )
 
 // GenerateHandler handles POST /api/generate.

--- a/internal/api/impl.go
+++ b/internal/api/impl.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/you/llamapool/api/generated"
-	"github.com/you/llamapool/internal/ctrl"
+	"github.com/gaspardpetit/llamapool/api/generated"
+	"github.com/gaspardpetit/llamapool/internal/ctrl"
 )
 
 type API struct {

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -6,7 +6,7 @@ import (
 
 	chiMiddleware "github.com/go-chi/chi/v5/middleware"
 
-	"github.com/you/llamapool/internal/logx"
+	"github.com/gaspardpetit/llamapool/internal/logx"
 )
 
 func MiddlewareChain() []func(http.Handler) http.Handler {

--- a/internal/api/models.go
+++ b/internal/api/models.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/you/llamapool/internal/ctrl"
-	"github.com/you/llamapool/internal/logx"
+	"github.com/gaspardpetit/llamapool/internal/ctrl"
+	"github.com/gaspardpetit/llamapool/internal/logx"
 )
 
 // ListModelsHandler handles GET /v1/models.

--- a/internal/api/state.go
+++ b/internal/api/state.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/you/llamapool/internal/ctrl"
-	"github.com/you/llamapool/internal/logx"
+	"github.com/gaspardpetit/llamapool/internal/ctrl"
+	"github.com/gaspardpetit/llamapool/internal/logx"
 )
 
 // StateHandler serves state snapshots and streams.

--- a/internal/api/state_test.go
+++ b/internal/api/state_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/you/llamapool/internal/ctrl"
+	"github.com/gaspardpetit/llamapool/internal/ctrl"
 )
 
 func TestGetState(t *testing.T) {

--- a/internal/api/tags.go
+++ b/internal/api/tags.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/you/llamapool/internal/ctrl"
-	"github.com/you/llamapool/internal/logx"
+	"github.com/gaspardpetit/llamapool/internal/ctrl"
+	"github.com/gaspardpetit/llamapool/internal/logx"
 )
 
 // TagsHandler handles GET /api/tags.

--- a/internal/ctrl/registry.go
+++ b/internal/ctrl/registry.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/you/llamapool/internal/logx"
+	"github.com/gaspardpetit/llamapool/internal/logx"
 )
 
 const (

--- a/internal/ctrl/ws.go
+++ b/internal/ctrl/ws.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/coder/websocket"
 
-	"github.com/you/llamapool/internal/logx"
+	"github.com/gaspardpetit/llamapool/internal/logx"
 )
 
 // WSHandler handles incoming worker websocket connections.

--- a/internal/ollama/client.go
+++ b/internal/ollama/client.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/you/llamapool/internal/relay"
+	"github.com/gaspardpetit/llamapool/internal/relay"
 )
 
 // Client is a tiny HTTP client for talking to local Ollama.

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -10,9 +10,9 @@ import (
 	chiMiddleware "github.com/go-chi/chi/v5/middleware"
 	"github.com/google/uuid"
 
-	"github.com/you/llamapool/internal/ctrl"
-	"github.com/you/llamapool/internal/logx"
-	"github.com/you/llamapool/internal/metrics"
+	"github.com/gaspardpetit/llamapool/internal/ctrl"
+	"github.com/gaspardpetit/llamapool/internal/logx"
+	"github.com/gaspardpetit/llamapool/internal/metrics"
 )
 
 // GenerateRequest is the minimal request for generation.

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/you/llamapool/internal/ctrl"
+	"github.com/gaspardpetit/llamapool/internal/ctrl"
 )
 
 func TestRelayGenerateStream(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -7,10 +7,10 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
-	"github.com/you/llamapool/api/generated"
-	"github.com/you/llamapool/internal/api"
-	"github.com/you/llamapool/internal/config"
-	"github.com/you/llamapool/internal/ctrl"
+	"github.com/gaspardpetit/llamapool/api/generated"
+	"github.com/gaspardpetit/llamapool/internal/api"
+	"github.com/gaspardpetit/llamapool/internal/config"
+	"github.com/gaspardpetit/llamapool/internal/ctrl"
 )
 
 // New constructs the HTTP handler for the server.
@@ -32,7 +32,7 @@ func New(reg *ctrl.Registry, metrics *ctrl.MetricsRegistry, sched ctrl.Scheduler
 		public.Post("/api/generate", wrapper.PostApiGenerate)
 		public.Get("/api/tags", wrapper.GetApiTags)
 		public.Get("/healthz", wrapper.GetHealthz)
-  	public.Get("/status", StatusHandler())
+		public.Get("/status", StatusHandler())
 	})
 
 	r.Group(func(v1 chi.Router) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/you/llamapool/internal/config"
-	"github.com/you/llamapool/internal/ctrl"
+	"github.com/gaspardpetit/llamapool/internal/config"
+	"github.com/gaspardpetit/llamapool/internal/ctrl"
 )
 
 func TestMetricsEndpointDefaultPort(t *testing.T) {

--- a/internal/worker/drain_integration_test.go
+++ b/internal/worker/drain_integration_test.go
@@ -11,9 +11,9 @@ import (
 	"time"
 
 	"github.com/coder/websocket"
-	"github.com/you/llamapool/internal/config"
-	"github.com/you/llamapool/internal/ctrl"
-	"github.com/you/llamapool/internal/relay"
+	"github.com/gaspardpetit/llamapool/internal/config"
+	"github.com/gaspardpetit/llamapool/internal/ctrl"
+	"github.com/gaspardpetit/llamapool/internal/relay"
 )
 
 func TestDrainAndTerminate(t *testing.T) {

--- a/internal/worker/health_test.go
+++ b/internal/worker/health_test.go
@@ -12,7 +12,7 @@ import (
 	"path/filepath"
 	"sync/atomic"
 
-	"github.com/you/llamapool/internal/ollama"
+	"github.com/gaspardpetit/llamapool/internal/ollama"
 )
 
 // fakeHealthClient implements healthClient for unit tests.

--- a/internal/worker/http_proxy.go
+++ b/internal/worker/http_proxy.go
@@ -10,9 +10,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/you/llamapool/internal/config"
-	"github.com/you/llamapool/internal/ctrl"
-	"github.com/you/llamapool/internal/logx"
+	"github.com/gaspardpetit/llamapool/internal/config"
+	"github.com/gaspardpetit/llamapool/internal/ctrl"
+	"github.com/gaspardpetit/llamapool/internal/logx"
 )
 
 func handleHTTPProxy(ctx context.Context, cfg config.WorkerConfig, sendCh chan []byte, req ctrl.HTTPProxyRequestMessage, cancels map[string]context.CancelFunc, mu *sync.Mutex, onDone func()) {

--- a/internal/worker/http_proxy_test.go
+++ b/internal/worker/http_proxy_test.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/you/llamapool/internal/config"
-	"github.com/you/llamapool/internal/ctrl"
+	"github.com/gaspardpetit/llamapool/internal/config"
+	"github.com/gaspardpetit/llamapool/internal/ctrl"
 )
 
 func TestHandleHTTPProxyAuthAndStream(t *testing.T) {

--- a/internal/worker/metrics.go
+++ b/internal/worker/metrics.go
@@ -6,9 +6,9 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/gaspardpetit/llamapool/internal/logx"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/you/llamapool/internal/logx"
 )
 
 var (

--- a/internal/worker/status_http.go
+++ b/internal/worker/status_http.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/you/llamapool/internal/logx"
+	"github.com/gaspardpetit/llamapool/internal/logx"
 )
 
 // StartStatusServer starts an HTTP server exposing status, version, and control endpoints.

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -11,11 +11,11 @@ import (
 	"github.com/coder/websocket"
 	"github.com/google/uuid"
 
-	"github.com/you/llamapool/internal/config"
-	"github.com/you/llamapool/internal/ctrl"
-	"github.com/you/llamapool/internal/logx"
-	"github.com/you/llamapool/internal/ollama"
-	"github.com/you/llamapool/internal/relay"
+	"github.com/gaspardpetit/llamapool/internal/config"
+	"github.com/gaspardpetit/llamapool/internal/ctrl"
+	"github.com/gaspardpetit/llamapool/internal/logx"
+	"github.com/gaspardpetit/llamapool/internal/ollama"
+	"github.com/gaspardpetit/llamapool/internal/relay"
 )
 
 // Run starts the worker agent.

--- a/test/e2e_api_key_test.go
+++ b/test/e2e_api_key_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/you/llamapool/internal/config"
-	"github.com/you/llamapool/internal/ctrl"
-	"github.com/you/llamapool/internal/server"
+	"github.com/gaspardpetit/llamapool/internal/config"
+	"github.com/gaspardpetit/llamapool/internal/ctrl"
+	"github.com/gaspardpetit/llamapool/internal/server"
 )
 
 func TestAPIKeyEnforcement(t *testing.T) {

--- a/test/e2e_auth_test.go
+++ b/test/e2e_auth_test.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/coder/websocket"
 
-	"github.com/you/llamapool/internal/config"
-	"github.com/you/llamapool/internal/ctrl"
-	"github.com/you/llamapool/internal/server"
+	"github.com/gaspardpetit/llamapool/internal/config"
+	"github.com/gaspardpetit/llamapool/internal/ctrl"
+	"github.com/gaspardpetit/llamapool/internal/server"
 )
 
 func TestWorkerAuth(t *testing.T) {

--- a/test/e2e_busy_test.go
+++ b/test/e2e_busy_test.go
@@ -8,10 +8,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/you/llamapool/internal/config"
-	"github.com/you/llamapool/internal/ctrl"
-	"github.com/you/llamapool/internal/relay"
-	"github.com/you/llamapool/internal/server"
+	"github.com/gaspardpetit/llamapool/internal/config"
+	"github.com/gaspardpetit/llamapool/internal/ctrl"
+	"github.com/gaspardpetit/llamapool/internal/relay"
+	"github.com/gaspardpetit/llamapool/internal/server"
 )
 
 func TestWorkerBusy(t *testing.T) {

--- a/test/e2e_cancel_test.go
+++ b/test/e2e_cancel_test.go
@@ -13,10 +13,10 @@ import (
 
 	"github.com/coder/websocket"
 
-	"github.com/you/llamapool/internal/config"
-	"github.com/you/llamapool/internal/ctrl"
-	"github.com/you/llamapool/internal/relay"
-	"github.com/you/llamapool/internal/server"
+	"github.com/gaspardpetit/llamapool/internal/config"
+	"github.com/gaspardpetit/llamapool/internal/ctrl"
+	"github.com/gaspardpetit/llamapool/internal/relay"
+	"github.com/gaspardpetit/llamapool/internal/server"
 )
 
 func TestCancelPropagates(t *testing.T) {

--- a/test/e2e_chat_completions_proxy_test.go
+++ b/test/e2e_chat_completions_proxy_test.go
@@ -12,10 +12,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/you/llamapool/internal/config"
-	"github.com/you/llamapool/internal/ctrl"
-	"github.com/you/llamapool/internal/server"
-	"github.com/you/llamapool/internal/worker"
+	"github.com/gaspardpetit/llamapool/internal/config"
+	"github.com/gaspardpetit/llamapool/internal/ctrl"
+	"github.com/gaspardpetit/llamapool/internal/server"
+	"github.com/gaspardpetit/llamapool/internal/worker"
 )
 
 func TestE2EChatCompletionsProxy(t *testing.T) {

--- a/test/e2e_models_api_test.go
+++ b/test/e2e_models_api_test.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/coder/websocket"
 
-	"github.com/you/llamapool/internal/config"
-	"github.com/you/llamapool/internal/ctrl"
-	"github.com/you/llamapool/internal/server"
+	"github.com/gaspardpetit/llamapool/internal/config"
+	"github.com/gaspardpetit/llamapool/internal/ctrl"
+	"github.com/gaspardpetit/llamapool/internal/server"
 )
 
 func TestModelsAPI(t *testing.T) {

--- a/test/e2e_prune_test.go
+++ b/test/e2e_prune_test.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/coder/websocket"
 
-	"github.com/you/llamapool/internal/config"
-	"github.com/you/llamapool/internal/ctrl"
-	"github.com/you/llamapool/internal/server"
+	"github.com/gaspardpetit/llamapool/internal/config"
+	"github.com/gaspardpetit/llamapool/internal/ctrl"
+	"github.com/gaspardpetit/llamapool/internal/server"
 )
 
 func TestHeartbeatPrune(t *testing.T) {

--- a/test/e2e_routes_test.go
+++ b/test/e2e_routes_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/you/llamapool/internal/config"
-	"github.com/you/llamapool/internal/ctrl"
-	"github.com/you/llamapool/internal/server"
+	"github.com/gaspardpetit/llamapool/internal/config"
+	"github.com/gaspardpetit/llamapool/internal/ctrl"
+	"github.com/gaspardpetit/llamapool/internal/server"
 )
 
 func TestRoutes(t *testing.T) {

--- a/test/e2e_server_worker_generate_test.go
+++ b/test/e2e_server_worker_generate_test.go
@@ -13,10 +13,10 @@ import (
 
 	"github.com/coder/websocket"
 
-	"github.com/you/llamapool/internal/config"
-	"github.com/you/llamapool/internal/ctrl"
-	"github.com/you/llamapool/internal/relay"
-	"github.com/you/llamapool/internal/server"
+	"github.com/gaspardpetit/llamapool/internal/config"
+	"github.com/gaspardpetit/llamapool/internal/ctrl"
+	"github.com/gaspardpetit/llamapool/internal/relay"
+	"github.com/gaspardpetit/llamapool/internal/server"
 )
 
 func TestE2EGenerateStream(t *testing.T) {


### PR DESCRIPTION
## Summary
- point module to `github.com/gaspardpetit/llamapool`
- update all internal imports to match new module path

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689ec64bf9b0832c805e1d721b501e73