### PR TITLE
Fix server build and configurable worker WS path

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,9 @@ PORT=8080 WORKER_KEY=secret API_KEY=test123 go run ./cmd/llamapool-server
 # PORT=8080 METRICS_PORT=9090 WORKER_KEY=secret API_KEY=test123 go run ./cmd/llamapool-server
 ```
 
+By default workers connect to `/api/workers/connect`; set `WS_PATH` or `--ws-path`
+to change the registration path.
+
 On Windows (CMD)
 
 ```

--- a/internal/api/embeddings.go
+++ b/internal/api/embeddings.go
@@ -56,7 +56,7 @@ func EmbeddingsHandler(reg *ctrl.Registry, sched ctrl.Scheduler) http.HandlerFun
 		worker.AddJob(reqID, ch)
 		defer func() {
 			worker.RemoveJob(reqID)
-			defer func() { recover() }()
+			_ = recover()
 			close(ch)
 		}()
 

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -12,6 +12,7 @@ type ServerConfig struct {
 	MetricsPort    int
 	APIKey         string
 	WorkerKey      string
+	WSPath         string
 	RequestTimeout time.Duration
 }
 
@@ -24,6 +25,7 @@ func (c *ServerConfig) BindFlags() {
 	c.MetricsPort = mp
 	c.APIKey = getEnv("API_KEY", "")
 	c.WorkerKey = getEnv("WORKER_KEY", "")
+	c.WSPath = getEnv("WS_PATH", "/api/workers/connect")
 	rt, _ := time.ParseDuration(getEnv("REQUEST_TIMEOUT", "60s"))
 	c.RequestTimeout = rt
 
@@ -31,5 +33,6 @@ func (c *ServerConfig) BindFlags() {
 	flag.IntVar(&c.MetricsPort, "metrics-port", c.MetricsPort, "Prometheus metrics listen port; defaults to the value of --port")
 	flag.StringVar(&c.APIKey, "api-key", c.APIKey, "client API key required for HTTP requests; leave empty to disable auth")
 	flag.StringVar(&c.WorkerKey, "worker-key", c.WorkerKey, "shared key workers must present when registering")
+	flag.StringVar(&c.WSPath, "ws-path", c.WSPath, "path workers use to establish WebSocket connections")
 	flag.DurationVar(&c.RequestTimeout, "request-timeout", c.RequestTimeout, "maximum duration to process a client request")
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -34,31 +34,37 @@ func New(reg *ctrl.Registry, metrics *ctrl.MetricsRegistry, sched ctrl.Scheduler
 		public.Get("/status", StatusHandler())
 	})
 
-	r.Group(func(apiGroup chi.Router) {
+	r.Route("/api", func(apiGroup chi.Router) {
 		if cfg.APIKey != "" {
 			apiGroup.Use(api.APIKeyMiddleware(cfg.APIKey))
 		}
-		v1.Post("/v1/chat/completions", wrapper.PostV1ChatCompletions)
-		v1.Post("/v1/embeddings", wrapper.PostV1Embeddings)
-		v1.Get("/v1/models", wrapper.GetV1Models)
-		v1.Get("/v1/models/{id}", wrapper.GetV1ModelsId)
-		apiGroup.Get("/api/state", wrapper.GetApiState)
-		apiGroup.Get("/api/state/stream", wrapper.GetApiStateStream)
+		apiGroup.Route("/v1", func(v1 chi.Router) {
+			v1.Post("/chat/completions", wrapper.PostV1ChatCompletions)
+			v1.Post("/embeddings", wrapper.PostV1Embeddings)
+			v1.Get("/models", wrapper.GetV1Models)
+			v1.Get("/models/{id}", wrapper.GetV1ModelsId)
+		})
+		apiGroup.Get("/state", wrapper.GetApiState)
+		apiGroup.Get("/state/stream", wrapper.GetApiStateStream)
 	})
 	mcpReg := mcp.NewRegistry()
 	r.Post("/mcp/{client_id}", mcpReg.HTTPHandler())
 	r.Handle("/ws/relay", mcpReg.WSHandler())
-	r.Handle(cfg.WSPath, ctrl.WSHandler(reg, metrics, cfg.WorkerKey))
+	wsPath := cfg.WSPath
+	if wsPath == "" {
+		wsPath = "/api/workers/connect"
+	}
+	r.Handle(wsPath, ctrl.WSHandler(reg, metrics, cfg.WorkerKey))
 
 	r.Group(func(openai chi.Router) {
 		if cfg.APIKey != "" {
 			openai.Use(api.APIKeyMiddleware(cfg.APIKey))
 		}
 		openai.Post("/v1/chat/completions", wrapper.PostV1ChatCompletions)
+		openai.Post("/v1/embeddings", wrapper.PostV1Embeddings)
 		openai.Get("/v1/models", wrapper.GetV1Models)
 		openai.Get("/v1/models/{id}", wrapper.GetV1ModelsId)
 	})
-	r.Handle("/api/workers/connect", ctrl.WSHandler(reg, metrics, cfg.WorkerKey))
 	metricsPort := cfg.MetricsPort
 	if metricsPort == 0 {
 		metricsPort = cfg.Port

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -15,7 +15,7 @@ func TestMetricsEndpointDefaultPort(t *testing.T) {
 	reg := ctrl.NewRegistry()
 	metricsReg := ctrl.NewMetricsRegistry("test", "", "")
 	sched := &ctrl.LeastBusyScheduler{Reg: reg}
-	cfg := config.ServerConfig{Port: 8080, RequestTimeout: time.Second}
+	cfg := config.ServerConfig{Port: 8080, RequestTimeout: time.Second, WSPath: "/api/workers/connect"}
 	h := New(reg, metricsReg, sched, cfg)
 	ts := httptest.NewServer(h)
 	defer ts.Close()
@@ -33,7 +33,7 @@ func TestMetricsEndpointSeparatePort(t *testing.T) {
 	reg := ctrl.NewRegistry()
 	metricsReg := ctrl.NewMetricsRegistry("test", "", "")
 	sched := &ctrl.LeastBusyScheduler{Reg: reg}
-	cfg := config.ServerConfig{Port: 8080, MetricsPort: 9090, RequestTimeout: time.Second}
+	cfg := config.ServerConfig{Port: 8080, MetricsPort: 9090, RequestTimeout: time.Second, WSPath: "/api/workers/connect"}
 	h := New(reg, metricsReg, sched, cfg)
 	ts := httptest.NewServer(h)
 	defer ts.Close()
@@ -51,7 +51,7 @@ func TestStatusPage(t *testing.T) {
 	reg := ctrl.NewRegistry()
 	metricsReg := ctrl.NewMetricsRegistry("test", "", "")
 	sched := &ctrl.LeastBusyScheduler{Reg: reg}
-	cfg := config.ServerConfig{Port: 8080, RequestTimeout: time.Second}
+	cfg := config.ServerConfig{Port: 8080, RequestTimeout: time.Second, WSPath: "/api/workers/connect"}
 	h := New(reg, metricsReg, sched, cfg)
 	ts := httptest.NewServer(h)
 	defer ts.Close()

--- a/test/e2e_api_key_test.go
+++ b/test/e2e_api_key_test.go
@@ -14,7 +14,7 @@ import (
 func TestAPIKeyEnforcement(t *testing.T) {
 	reg := ctrl.NewRegistry()
 	sched := &ctrl.LeastBusyScheduler{Reg: reg}
-	cfg := config.ServerConfig{APIKey: "test123", RequestTimeout: 5 * time.Second}
+	cfg := config.ServerConfig{APIKey: "test123", RequestTimeout: 5 * time.Second, WSPath: "/api/workers/connect"}
 	metricsReg := ctrl.NewMetricsRegistry("test", "", "")
 	handler := server.New(reg, metricsReg, sched, cfg)
 	srv := httptest.NewServer(handler)


### PR DESCRIPTION
## Summary
- fix API router setup and add OpenAI embeddings route
- add `WS_PATH`/`--ws-path` option for worker registration
- handle recover in embeddings handler and update docs/tests

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689ee8b15e3c832cb4577c5cc2698676