### PR TITLE
feat(windows): improve worker service lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ xcrun stapler staple build/Llamapool.dmg
 A Windows tray companion lives under `desktop/windows/`. It polls `http://127.0.0.1:4555/status` every two seconds to display worker status.
 The tray can start or stop the local `llamapool` Windows service, toggle whether it launches automatically with Windows, edit worker connection settings, open the config and logs folders, view live logs, and collect diagnostics to the Desktop. When the worker exposes lifecycle control endpoints, the tray also provides **Drain**, **Undrain**, and **Shutdown after drain** actions.
 
+The Windows service runs `llamapool-worker` with the `--reconnect` flag and will shut down if the worker process exits, preventing orphaned workers.
+
 ### Key features
 - **Dynamic worker discovery** – Workers can connect and disconnect at any time; the server updates the available model list in real-time.
 - **Least-busy routing** – If multiple workers support the same model, the server dispatches requests to the one with the lowest current load.

--- a/desktop/windows/WindowsService/Worker.cs
+++ b/desktop/windows/WindowsService/Worker.cs
@@ -1,16 +1,21 @@
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
+using Microsoft.Extensions.Hosting;
 
 namespace WindowsService;
 
 public class Worker : BackgroundService
 {
     private readonly ILogger<Worker> _logger;
+    private readonly IHostApplicationLifetime _lifetime;
     private Process? _process;
 
-    public Worker(ILogger<Worker> logger)
+    public Worker(ILogger<Worker> logger, IHostApplicationLifetime lifetime)
     {
         _logger = logger;
+        _lifetime = lifetime;
+        AppDomain.CurrentDomain.ProcessExit += (_, _) => TryKillWorker();
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -28,10 +33,17 @@ public class Worker : BackgroundService
         var configPath = Path.Combine(dataDir, "worker.yaml");
         var logPath = Path.Combine(logsDir, "worker.log");
 
+        if (Process.GetProcessesByName(Path.GetFileNameWithoutExtension(workerExe)).Any())
+        {
+            _logger.LogWarning("llamapool-worker is already running; exiting service");
+            _lifetime.StopApplication();
+            return;
+        }
+
         var psi = new ProcessStartInfo
         {
             FileName = workerExe,
-            Arguments = $"--status-addr 127.0.0.1:4555 --config \"{configPath}\"",
+            Arguments = $"--status-addr 127.0.0.1:4555 --config \"{configPath}\" --reconnect",
             WorkingDirectory = dataDir,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
@@ -40,6 +52,14 @@ public class Worker : BackgroundService
         };
 
         _process = new Process { StartInfo = psi, EnableRaisingEvents = true };
+        _process.Exited += (_, _) =>
+        {
+            if (!stoppingToken.IsCancellationRequested)
+            {
+                _logger.LogWarning("worker process exited with code {ExitCode}", _process?.ExitCode);
+                _lifetime.StopApplication();
+            }
+        };
 
         try
         {
@@ -52,31 +72,46 @@ public class Worker : BackgroundService
             _process.BeginErrorReadLine();
 
             await _process.WaitForExitAsync(stoppingToken);
+
+            if (!stoppingToken.IsCancellationRequested)
+            {
+                _lifetime.StopApplication();
+            }
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to run worker process");
+            _lifetime.StopApplication();
         }
     }
 
     public override Task StopAsync(CancellationToken cancellationToken)
     {
-        if (_process != null && !_process.HasExited)
+        TryKillWorker();
+        return base.StopAsync(cancellationToken);
+    }
+
+    private void TryKillWorker()
+    {
+        if (_process == null)
         {
-            try
+            return;
+        }
+
+        try
+        {
+            if (!_process.HasExited)
             {
                 _process.CloseMainWindow();
                 if (!_process.WaitForExit(5000))
                 {
-                    _process.Kill();
+                    _process.Kill(entireProcessTree: true);
                 }
             }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to stop worker process gracefully");
-            }
         }
-
-        return base.StopAsync(cancellationToken);
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to stop worker process gracefully");
+        }
     }
 }


### PR DESCRIPTION
## Summary
- launch Windows worker with `--reconnect`
- stop service when worker exits and kill worker on service shutdown
- document Windows service behavior in README

## Testing
- `dotnet format desktop/windows/WindowsService/WindowsService.csproj`
- `dotnet build desktop/windows/WindowsService/WindowsService.csproj`
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689f66d2e7c0832caac8ffb9c7b84423