### PR TITLE
Fix worker status reporting in server metrics

### DIFF
--- a/internal/api/chat_completions.go
+++ b/internal/api/chat_completions.go
@@ -12,10 +12,11 @@ import (
 
 	"github.com/gaspardpetit/llamapool/internal/ctrl"
 	"github.com/gaspardpetit/llamapool/internal/logx"
+	"github.com/gaspardpetit/llamapool/internal/metrics"
 )
 
 // ChatCompletionsHandler handles POST /v1/chat/completions as a pass-through.
-func ChatCompletionsHandler(reg *ctrl.Registry, sched ctrl.Scheduler) http.HandlerFunc {
+func ChatCompletionsHandler(reg *ctrl.Registry, sched ctrl.Scheduler, metricsReg *ctrl.MetricsRegistry) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Body == nil {
 			http.Error(w, "bad request", http.StatusBadRequest)
@@ -89,6 +90,8 @@ func ChatCompletionsHandler(reg *ctrl.Registry, sched ctrl.Scheduler) http.Handl
 		}
 		select {
 		case worker.Send <- msg:
+			metricsReg.RecordJobStart(worker.ID)
+			metricsReg.SetWorkerStatus(worker.ID, ctrl.StatusWorking)
 		default:
 			logx.Log.Warn().Str("request_id", logID).Str("worker_id", worker.ID).Str("worker_name", worker.Name).Str("model", meta.Model).Msg("worker busy")
 			w.Header().Set("Content-Type", "application/json")
@@ -104,6 +107,16 @@ func ChatCompletionsHandler(reg *ctrl.Registry, sched ctrl.Scheduler) http.Handl
 		start := time.Now()
 		headersSent := false
 		bytesSent := false
+		success := false
+		var errMsg string
+
+		defer func() {
+			dur := time.Since(start)
+			metricsReg.RecordJobEnd(worker.ID, meta.Model, dur, 0, 0, success, errMsg)
+			metricsReg.SetWorkerStatus(worker.ID, ctrl.StatusIdle)
+			metrics.ObserveRequestDuration(worker.ID, meta.Model, dur)
+			metrics.RecordModelRequest(meta.Model, success)
+		}()
 		for {
 			select {
 			case <-ctx.Done():
@@ -121,6 +134,7 @@ func ChatCompletionsHandler(reg *ctrl.Registry, sched ctrl.Scheduler) http.Handl
 							logx.Log.Error().Err(err).Msg("write upstream error")
 						}
 					}
+					errMsg = "closed"
 					return
 				}
 				switch m := msg.(type) {
@@ -159,6 +173,9 @@ func ChatCompletionsHandler(reg *ctrl.Registry, sched ctrl.Scheduler) http.Handl
 						if _, err := w.Write([]byte(`{"error":"upstream_error"}`)); err != nil {
 							logx.Log.Error().Err(err).Msg("write upstream error")
 						}
+						errMsg = m.Error.Message
+					} else {
+						success = true
 					}
 					logx.Log.Info().Str("request_id", logID).Str("worker_id", worker.ID).Str("worker_name", worker.Name).Str("model", meta.Model).Bool("stream", meta.Stream).Dur("duration", time.Since(start)).Msg("complete")
 					return

--- a/internal/api/chat_completions_test.go
+++ b/internal/api/chat_completions_test.go
@@ -22,7 +22,8 @@ func TestChatCompletionsHeaders(t *testing.T) {
 	sched := &ctrl.LeastBusyScheduler{Reg: reg}
 	wk := &ctrl.Worker{ID: "w1", Models: map[string]bool{"m": true}, Send: make(chan interface{}, 1), Jobs: make(map[string]chan interface{})}
 	reg.Add(wk)
-	h := ChatCompletionsHandler(reg, sched)
+	metricsReg := ctrl.NewMetricsRegistry("", "", "")
+	h := ChatCompletionsHandler(reg, sched, metricsReg)
 
 	go func() {
 		msg := <-wk.Send
@@ -57,7 +58,8 @@ func TestChatCompletionsOpaque(t *testing.T) {
 	sched := &ctrl.LeastBusyScheduler{Reg: reg}
 	wk := &ctrl.Worker{ID: "w1", Models: map[string]bool{"m": true}, Send: make(chan interface{}, 1), Jobs: make(map[string]chan interface{})}
 	reg.Add(wk)
-	h := ChatCompletionsHandler(reg, sched)
+	metricsReg := ctrl.NewMetricsRegistry("", "", "")
+	h := ChatCompletionsHandler(reg, sched, metricsReg)
 
 	go func() {
 		msg := <-wk.Send
@@ -83,7 +85,8 @@ func TestChatCompletionsEarlyError(t *testing.T) {
 	sched := &ctrl.LeastBusyScheduler{Reg: reg}
 	wk := &ctrl.Worker{ID: "w1", Models: map[string]bool{"m": true}, Send: make(chan interface{}, 1), Jobs: make(map[string]chan interface{})}
 	reg.Add(wk)
-	h := ChatCompletionsHandler(reg, sched)
+	metricsReg := ctrl.NewMetricsRegistry("", "", "")
+	h := ChatCompletionsHandler(reg, sched, metricsReg)
 
 	go func() {
 		msg := <-wk.Send

--- a/internal/api/embeddings_test.go
+++ b/internal/api/embeddings_test.go
@@ -15,7 +15,8 @@ func TestEmbeddings(t *testing.T) {
 	sched := &ctrl.LeastBusyScheduler{Reg: reg}
 	wk := &ctrl.Worker{ID: "w1", Models: map[string]bool{"m": true}, Send: make(chan interface{}, 1), Jobs: make(map[string]chan interface{})}
 	reg.Add(wk)
-	h := EmbeddingsHandler(reg, sched)
+	metricsReg := ctrl.NewMetricsRegistry("", "", "")
+	h := EmbeddingsHandler(reg, sched, metricsReg)
 
 	go func() {
 		msg := <-wk.Send
@@ -43,7 +44,8 @@ func TestEmbeddingsEarlyError(t *testing.T) {
 	sched := &ctrl.LeastBusyScheduler{Reg: reg}
 	wk := &ctrl.Worker{ID: "w1", Models: map[string]bool{"m": true}, Send: make(chan interface{}, 1), Jobs: make(map[string]chan interface{})}
 	reg.Add(wk)
-	h := EmbeddingsHandler(reg, sched)
+	metricsReg := ctrl.NewMetricsRegistry("", "", "")
+	h := EmbeddingsHandler(reg, sched, metricsReg)
 
 	go func() {
 		msg := <-wk.Send

--- a/internal/api/impl.go
+++ b/internal/api/impl.go
@@ -23,11 +23,11 @@ func (a *API) GetHealthz(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) PostV1ChatCompletions(w http.ResponseWriter, r *http.Request) {
-	ChatCompletionsHandler(a.Reg, a.Sched)(w, r)
+	ChatCompletionsHandler(a.Reg, a.Sched, a.Metrics)(w, r)
 }
 
 func (a *API) PostV1Embeddings(w http.ResponseWriter, r *http.Request) {
-	EmbeddingsHandler(a.Reg, a.Sched)(w, r)
+	EmbeddingsHandler(a.Reg, a.Sched, a.Metrics)(w, r)
 }
 
 func (a *API) GetV1Models(w http.ResponseWriter, r *http.Request) {

--- a/internal/ctrl/messages.go
+++ b/internal/ctrl/messages.go
@@ -10,6 +10,9 @@ type RegisterMessage struct {
 	Token          string   `json:"token,omitempty"`
 	Models         []string `json:"models"`
 	MaxConcurrency int      `json:"max_concurrency"`
+	Version        string   `json:"version,omitempty"`
+	BuildSHA       string   `json:"build_sha,omitempty"`
+	BuildDate      string   `json:"build_date,omitempty"`
 }
 
 type HeartbeatMessage struct {

--- a/internal/ctrl/ws.go
+++ b/internal/ctrl/ws.go
@@ -72,7 +72,7 @@ func WSHandler(reg *Registry, metrics *MetricsRegistry, workerKey string) http.H
 			wk.Models[m] = true
 		}
 		reg.Add(wk)
-		metrics.UpsertWorker(wk.ID, "", "", "", rm.Models)
+		metrics.UpsertWorker(wk.ID, rm.Version, rm.BuildSHA, rm.BuildDate, rm.Models)
 		metrics.SetWorkerStatus(wk.ID, StatusIdle)
 		logx.Log.Info().Str("worker_id", wk.ID).Str("worker_name", wk.Name).Int("model_count", len(wk.Models)).Msg("registered")
 		defer func() {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -106,7 +106,18 @@ func connectAndServe(ctx context.Context, cfg config.WorkerConfig, client *ollam
 		}
 	}()
 
-	regMsg := ctrl.RegisterMessage{Type: "register", WorkerID: cfg.WorkerID, WorkerName: cfg.WorkerName, WorkerKey: cfg.WorkerKey, Models: GetState().Models, MaxConcurrency: cfg.MaxConcurrency}
+	vi := GetVersionInfo()
+	regMsg := ctrl.RegisterMessage{
+		Type:           "register",
+		WorkerID:       cfg.WorkerID,
+		WorkerName:     cfg.WorkerName,
+		WorkerKey:      cfg.WorkerKey,
+		Models:         GetState().Models,
+		MaxConcurrency: cfg.MaxConcurrency,
+		Version:        vi.Version,
+		BuildSHA:       vi.BuildSHA,
+		BuildDate:      vi.BuildDate,
+	}
 	b, _ := json.Marshal(regMsg)
 	sendCh <- b
 


### PR DESCRIPTION
## Summary
- track job lifecycle in chat completions and embeddings handlers to update worker status
- include version metadata in worker registration and propagate to server

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689f69186784832cbc9556121f86d01b