### PR TITLE
Ensure Windows service terminates worker on service kill

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ xcrun stapler staple build/Llamapool.dmg
 A Windows tray companion lives under `desktop/windows/`. It polls `http://127.0.0.1:4555/status` every two seconds to display worker status.
 The tray can start or stop the local `llamapool` Windows service, toggle whether it launches automatically with Windows, edit worker connection settings, open the config and logs folders, view live logs, and collect diagnostics to the Desktop. When the worker exposes lifecycle control endpoints, the tray also provides **Drain**, **Undrain**, and **Shutdown after drain** actions.
 
-The Windows service runs `llamapool-worker` with the `--reconnect` flag and will shut down if the worker process exits, preventing orphaned workers.
+The Windows service runs `llamapool-worker` with the `--reconnect` flag and shuts down if the worker process exits, preventing orphaned workers. The worker is attached to a job object so it also terminates if the service process is killed.
 
 ### Key features
 - **Dynamic worker discovery** – Workers can connect and disconnect at any time; the server updates the available model list in real-time.

--- a/desktop/windows/WindowsService/JobObject.cs
+++ b/desktop/windows/WindowsService/JobObject.cs
@@ -1,0 +1,120 @@
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+
+namespace WindowsService;
+
+internal sealed class JobObject : IDisposable
+{
+    private IntPtr _handle;
+
+    public JobObject()
+    {
+        _handle = CreateJobObject(IntPtr.Zero, null);
+        if (_handle == IntPtr.Zero)
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        var info = new JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+        {
+            BasicLimitInformation = new JOBOBJECT_BASIC_LIMIT_INFORMATION
+            {
+                LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+            }
+        };
+
+        int length = Marshal.SizeOf<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>();
+        IntPtr infoPtr = Marshal.AllocHGlobal(length);
+        try
+        {
+            Marshal.StructureToPtr(info, infoPtr, false);
+            if (!SetInformationJobObject(_handle, JobObjectInfoType.ExtendedLimitInformation, infoPtr, (uint)length))
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(infoPtr);
+        }
+    }
+
+    public void AddProcess(IntPtr processHandle)
+    {
+        if (!AssignProcessToJobObject(_handle, processHandle))
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_handle != IntPtr.Zero)
+        {
+            CloseHandle(_handle);
+            _handle = IntPtr.Zero;
+        }
+        GC.SuppressFinalize(this);
+    }
+
+    ~JobObject()
+    {
+        Dispose();
+    }
+
+    private const int JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x00002000;
+
+    private enum JobObjectInfoType
+    {
+        BasicLimitInformation = 2,
+        ExtendedLimitInformation = 9,
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct IO_COUNTERS
+    {
+        public ulong ReadOperationCount;
+        public ulong WriteOperationCount;
+        public ulong OtherOperationCount;
+        public ulong ReadTransferCount;
+        public ulong WriteTransferCount;
+        public ulong OtherTransferCount;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct JOBOBJECT_BASIC_LIMIT_INFORMATION
+    {
+        public long PerProcessUserTimeLimit;
+        public long PerJobUserTimeLimit;
+        public int LimitFlags;
+        public UIntPtr MinimumWorkingSetSize;
+        public UIntPtr MaximumWorkingSetSize;
+        public int ActiveProcessLimit;
+        public IntPtr Affinity;
+        public int PriorityClass;
+        public int SchedulingClass;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+    {
+        public JOBOBJECT_BASIC_LIMIT_INFORMATION BasicLimitInformation;
+        public IO_COUNTERS IoInfo;
+        public UIntPtr ProcessMemoryLimit;
+        public UIntPtr JobMemoryLimit;
+        public UIntPtr PeakProcessMemoryUsed;
+        public UIntPtr PeakJobMemoryUsed;
+    }
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+    private static extern IntPtr CreateJobObject(IntPtr lpJobAttributes, string? name);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool SetInformationJobObject(IntPtr hJob, JobObjectInfoType infoType, IntPtr lpJobObjectInfo, uint cbJobObjectInfoLength);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool AssignProcessToJobObject(IntPtr job, IntPtr process);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool CloseHandle(IntPtr hObject);
+}


### PR DESCRIPTION
## Summary
- attach worker process to a Job object so it dies when the Windows service is killed
- dispose job on shutdown and document behavior in README

## Testing
- `make lint`
- `make build`
- `make test`
- `dotnet build desktop/windows/WindowsService/WindowsService.csproj`


------
https://chatgpt.com/codex/tasks/task_e_689f6c15da44832ca4d2a3121a256428