### PR TITLE
feat: negotiate mcp capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 **llamapool** is a lightweight, distributed worker pool that exposes an OpenAI-compatible `chat/completions` API, forwarding requests to one or more connected **LLM workers**.
 It sits in front of existing LLM runtimes such as [Ollama](https://github.com/ollama/ollama), [vLLM](https://github.com/vllm-project/vllm), or [Open-WebUI](https://github.com/open-webui/open-webui), allowing you to scale, load-balance, and securely access them from anywhere.
 
-In addition to LLM workers, llamapool now supports relaying [Model Context Protocol](https://github.com/modelcontextprotocol) calls. The new `llamapool-mcp` binary connects a private MCP provider to the public `llamapool-server`, allowing clients to invoke MCP methods via `POST /mcp/{client_id}`. The broker enforces request/response size limits, per-client concurrency caps, and 30s call timeouts; cancellation is not yet implemented.
+In addition to LLM workers, llamapool now supports relaying [Model Context Protocol](https://github.com/modelcontextprotocol) calls. The new `llamapool-mcp` binary connects a private MCP provider to the public `llamapool-server`, allowing clients to invoke MCP methods via `POST /mcp/{client_id}`. The broker enforces request/response size limits, per-client concurrency caps, and 30s call timeouts; cancellation is not yet implemented. The client negotiates protocol versions and server capabilities, and exposes tunables such as `MCP_PROTOCOL_VERSION`, `MCP_HTTP_TIMEOUT`, and `MCP_MAX_INFLIGHT` for advanced deployments.
 
 A typical deployment looks like this:
 

--- a/internal/mcpclient/connector.go
+++ b/internal/mcpclient/connector.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"slices"
 	"sync/atomic"
+	"time"
 
 	"github.com/mark3labs/mcp-go/client/transport"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -17,6 +19,9 @@ type Connector interface {
 	Start(ctx context.Context) error
 	Initialize(ctx context.Context, req mcp.InitializeRequest) (*mcp.InitializeResult, error)
 	DoRPC(ctx context.Context, method string, params any, result any) error
+	Capabilities() mcp.ServerCapabilities
+	Protocol() string
+	Features() Features
 	Close() error
 }
 
@@ -26,10 +31,16 @@ type transportConnector struct {
 	id         atomic.Int64
 	serverCaps mcp.ServerCapabilities
 	protocol   string
+	features   Features
+	sem        chan struct{}
 }
 
-func newTransportConnector(t transport.Interface) *transportConnector {
-	return &transportConnector{t: t}
+func newTransportConnector(t transport.Interface, maxInFlight int) *transportConnector {
+	var sem chan struct{}
+	if maxInFlight > 0 {
+		sem = make(chan struct{}, maxInFlight)
+	}
+	return &transportConnector{t: t, sem: sem}
 }
 
 func (c *transportConnector) Start(ctx context.Context) error {
@@ -57,12 +68,21 @@ func (c *transportConnector) Initialize(ctx context.Context, req mcp.InitializeR
 	}
 	c.serverCaps = res.Capabilities
 	c.protocol = res.ProtocolVersion
+	c.features = deriveFeatures(res.Capabilities)
 	// best effort notification
 	_ = c.t.SendNotification(ctx, mcp.JSONRPCNotification{JSONRPC: mcp.JSONRPC_VERSION, Notification: mcp.Notification{Method: "notifications/initialized"}})
 	return &res, nil
 }
 
 func (c *transportConnector) DoRPC(ctx context.Context, method string, params any, result any) error {
+	if c.sem != nil {
+		select {
+		case c.sem <- struct{}{}:
+			defer func() { <-c.sem }()
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
 	id := c.id.Add(1)
 	req := transport.JSONRPCRequest{JSONRPC: mcp.JSONRPC_VERSION, ID: mcp.NewRequestId(id), Method: method, Params: params}
 	resp, err := c.t.SendRequest(ctx, req)
@@ -78,6 +98,10 @@ func (c *transportConnector) DoRPC(ctx context.Context, method string, params an
 	return nil
 }
 
+func (c *transportConnector) Capabilities() mcp.ServerCapabilities { return c.serverCaps }
+func (c *transportConnector) Protocol() string                     { return c.protocol }
+func (c *transportConnector) Features() Features                   { return c.features }
+
 // Constructors for specific transports
 
 func newStdioConnector(cfg Config) (*transportConnector, error) {
@@ -85,34 +109,44 @@ func newStdioConnector(cfg Config) (*transportConnector, error) {
 		return nil, fmt.Errorf("stdio command not configured")
 	}
 	t := transport.NewStdio(cfg.Stdio.Command, cfg.Stdio.Env, cfg.Stdio.Args...)
-	return newTransportConnector(t), nil
+	return newTransportConnector(t, cfg.MaxInFlight), nil
 }
 
 func newHTTPConnector(cfg Config) (*transportConnector, error) {
 	if cfg.HTTP.URL == "" {
 		return nil, fmt.Errorf("http url not configured")
 	}
-	t, err := transport.NewStreamableHTTP(cfg.HTTP.URL)
+	client := &http.Client{Timeout: cfg.HTTP.Timeout, Transport: &http.Transport{MaxIdleConns: 100, MaxIdleConnsPerHost: 10, IdleConnTimeout: 90 * time.Second}}
+	opts := []transport.StreamableHTTPCOption{transport.WithHTTPBasicClient(client), transport.WithHTTPTimeout(cfg.HTTP.Timeout)}
+	if cfg.HTTP.EnablePush {
+		opts = append(opts, transport.WithContinuousListening())
+	}
+	t, err := transport.NewStreamableHTTP(cfg.HTTP.URL, opts...)
 	if err != nil {
 		return nil, err
 	}
-	return newTransportConnector(t), nil
+	return newTransportConnector(t, cfg.MaxInFlight), nil
 }
 
 func newOAuthHTTPConnector(cfg Config) (*transportConnector, error) {
 	if !cfg.OAuth.Enabled {
 		return nil, fmt.Errorf("oauth disabled")
 	}
-	t, err := transport.NewStreamableHTTP(cfg.HTTP.URL, transport.WithHTTPOAuth(transport.OAuthConfig{
+	client := &http.Client{Timeout: cfg.HTTP.Timeout, Transport: &http.Transport{MaxIdleConns: 100, MaxIdleConnsPerHost: 10, IdleConnTimeout: 90 * time.Second}}
+	opts := []transport.StreamableHTTPCOption{transport.WithHTTPBasicClient(client), transport.WithHTTPTimeout(cfg.HTTP.Timeout), transport.WithHTTPOAuth(transport.OAuthConfig{
 		ClientID:              cfg.OAuth.ClientID,
 		ClientSecret:          cfg.OAuth.ClientSecret,
 		Scopes:                cfg.OAuth.Scopes,
 		AuthServerMetadataURL: cfg.OAuth.TokenURL,
-	}))
+	})}
+	if cfg.HTTP.EnablePush {
+		opts = append(opts, transport.WithContinuousListening())
+	}
+	t, err := transport.NewStreamableHTTP(cfg.HTTP.URL, opts...)
 	if err != nil {
 		return nil, err
 	}
-	return newTransportConnector(t), nil
+	return newTransportConnector(t, cfg.MaxInFlight), nil
 }
 
 func newLegacySSEConnector(cfg Config) (*transportConnector, error) {
@@ -126,5 +160,26 @@ func newLegacySSEConnector(cfg Config) (*transportConnector, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newTransportConnector(t), nil
+	return newTransportConnector(t, cfg.MaxInFlight), nil
+}
+
+// Features describes server-supported capabilities for gating behavior.
+type Features struct {
+	Tools        bool
+	Resources    bool
+	Prompts      bool
+	Logging      bool
+	Sampling     bool
+	Experimental map[string]any
+}
+
+func deriveFeatures(caps mcp.ServerCapabilities) Features {
+	return Features{
+		Tools:        caps.Tools != nil,
+		Resources:    caps.Resources != nil,
+		Prompts:      caps.Prompts != nil,
+		Logging:      caps.Logging != nil,
+		Sampling:     caps.Sampling != nil,
+		Experimental: caps.Experimental,
+	}
 }

--- a/internal/mcpclient/connector_test.go
+++ b/internal/mcpclient/connector_test.go
@@ -1,0 +1,52 @@
+package mcpclient
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/client/transport"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+type fakeInitTransport struct{ res mcp.InitializeResult }
+
+func (f *fakeInitTransport) Start(context.Context) error { return nil }
+func (f *fakeInitTransport) SendRequest(ctx context.Context, req transport.JSONRPCRequest) (*transport.JSONRPCResponse, error) {
+	if req.Method == string(mcp.MethodInitialize) {
+		b, _ := json.Marshal(f.res)
+		return &transport.JSONRPCResponse{Result: b}, nil
+	}
+	return &transport.JSONRPCResponse{Result: json.RawMessage(`{}`)}, nil
+}
+func (f *fakeInitTransport) SendNotification(context.Context, mcp.JSONRPCNotification) error {
+	return nil
+}
+func (f *fakeInitTransport) SetNotificationHandler(func(mcp.JSONRPCNotification)) {}
+func (f *fakeInitTransport) Close() error                                         { return nil }
+func (f *fakeInitTransport) GetSessionId() string                                 { return "" }
+
+func TestFeatureDerivation(t *testing.T) {
+	caps := mcp.ServerCapabilities{
+		Tools: &struct {
+			ListChanged bool `json:"listChanged,omitempty"`
+		}{},
+		Experimental: map[string]any{"progress": true},
+	}
+	ft := &fakeInitTransport{res: mcp.InitializeResult{ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION, Capabilities: caps}}
+	conn := newTransportConnector(ft, 0)
+	req := mcp.InitializeRequest{Params: mcp.InitializeParams{ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION}}
+	if _, err := conn.Initialize(context.Background(), req); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+	feats := conn.Features()
+	if !feats.Tools {
+		t.Fatalf("expected tools feature")
+	}
+	if feats.Resources {
+		t.Fatalf("unexpected resources feature")
+	}
+	if _, ok := feats.Experimental["progress"]; !ok {
+		t.Fatalf("experimental progress not recorded")
+	}
+}

--- a/internal/mcpclient/orchestrator_test.go
+++ b/internal/mcpclient/orchestrator_test.go
@@ -51,13 +51,13 @@ func TestOrchestratorFallback(t *testing.T) {
 	o := NewOrchestrator(cfg)
 	var calls []string
 	o.factories["stdio"] = func(Config) (*transportConnector, error) {
-		return newTransportConnector(&fakeTransport{name: "stdio", calls: &calls, startErr: errors.New("boom")}), nil
+		return newTransportConnector(&fakeTransport{name: "stdio", calls: &calls, startErr: errors.New("boom")}, 0), nil
 	}
 	o.factories["http"] = func(Config) (*transportConnector, error) {
-		return newTransportConnector(&fakeTransport{name: "http", calls: &calls, initErr: errors.New("init")}), nil
+		return newTransportConnector(&fakeTransport{name: "http", calls: &calls, initErr: errors.New("init")}, 0), nil
 	}
 	o.factories["oauth"] = func(Config) (*transportConnector, error) {
-		return newTransportConnector(&fakeTransport{name: "oauth", calls: &calls}), nil
+		return newTransportConnector(&fakeTransport{name: "oauth", calls: &calls}, 0), nil
 	}
 	conn, err := o.Connect(context.Background())
 	if err != nil {


### PR DESCRIPTION
## Summary
- expose protocol version, HTTP timeout, push channel and in-flight limit options
- derive server features during MCP initialization and gate concurrency
- warn on protocol downgrade when connecting

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689f83315674832c9fb3c2f0409f1eb0