### PR TITLE
feat: define mcp ingress bridge frame

### DIFF
--- a/doc/adr/0002-mcp-ingress-bridge.md
+++ b/doc/adr/0002-mcp-ingress-bridge.md
@@ -1,0 +1,30 @@
+# ADR 0002: MCP ingress bridge frame schema
+
+## Context
+The public `llamapool-server` will accept MCP client traffic over Streamable HTTP and relay it to `llamapool-mcp` via WebSocket. To keep the relay transport-agnostic and opaque, we need a well-defined frame format and correlation rules for JSON-RPC messages.
+
+## Decision
+Define a WebSocket frame schema used between the ingress and the downstream bridge:
+
+```json
+{
+  "type": "request | response | notification | server_request | server_response | stream_event",
+  "id": "<corrId>",
+  "sessionId": "<mcp-session-id>",
+  "payload": { "...opaque json-rpc..." },
+  "meta": { "optional tracing or timestamps" }
+}
+```
+
+* Every client JSON-RPC request is assigned an internal correlation ID (`corrId`).
+* The mapper stores the original JSON-RPC `id` as raw bytes keyed by `corrId`.
+* Downstream responses and streamed events use the same `corrId` in the WebSocket frame.
+* When forwarding back to the client, the mapper restores the original JSON-RPC `id` and removes the mapping.
+
+No attempt is made to parse or validate the JSON-RPC payloads; they remain opaque.
+
+## Consequences
+- Enables transparent, bidirectional forwarding between HTTP clients and the internal WebSocket bridge.
+- Keeps future enhancements (logging, tracing, quotas) decoupled from JSON-RPC semantics.
+- Simple ID mapper guarantees correct correlation while avoiding payload interpretation.
+

--- a/internal/mcpbridge/frame.go
+++ b/internal/mcpbridge/frame.go
@@ -1,0 +1,24 @@
+package mcpbridge
+
+import "encoding/json"
+
+// FrameType enumerates bridge frame types.
+type FrameType string
+
+const (
+	TypeRequest        FrameType = "request"
+	TypeResponse       FrameType = "response"
+	TypeNotification   FrameType = "notification"
+	TypeServerRequest  FrameType = "server_request"
+	TypeServerResponse FrameType = "server_response"
+	TypeStreamEvent    FrameType = "stream_event"
+)
+
+// Frame carries an opaque JSON-RPC payload across the bridge.
+type Frame struct {
+	Type      FrameType       `json:"type"`
+	ID        string          `json:"id,omitempty"`
+	SessionID string          `json:"sessionId"`
+	Payload   json.RawMessage `json:"payload,omitempty"`
+	Meta      json.RawMessage `json:"meta,omitempty"`
+}

--- a/internal/mcpbridge/frame_test.go
+++ b/internal/mcpbridge/frame_test.go
@@ -1,0 +1,22 @@
+package mcpbridge
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestFramePayloadRoundTrip(t *testing.T) {
+	raw := json.RawMessage(`{"jsonrpc":"2.0","method":"ping","params":{"a":1}}`)
+	f := Frame{Type: TypeRequest, ID: "1", SessionID: "s", Payload: raw}
+	b, err := json.Marshal(f)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got Frame
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if string(got.Payload) != string(raw) {
+		t.Fatalf("payload changed: %s != %s", got.Payload, raw)
+	}
+}

--- a/internal/mcpbridge/idmap.go
+++ b/internal/mcpbridge/idmap.go
@@ -1,0 +1,42 @@
+package mcpbridge
+
+import (
+	"encoding/json"
+	"strconv"
+	"sync"
+)
+
+// IDMapper manages correlation IDs for JSON-RPC requests.
+type IDMapper struct {
+	mu    sync.Mutex
+	next  uint64
+	store map[string]json.RawMessage
+}
+
+// NewIDMapper constructs a new IDMapper.
+func NewIDMapper() *IDMapper {
+	return &IDMapper{store: make(map[string]json.RawMessage)}
+}
+
+// Alloc assigns a new correlation ID for the given JSON-RPC id.
+// It stores the original id for later lookup.
+func (m *IDMapper) Alloc(jsonID json.RawMessage) string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	id := strconv.FormatUint(m.next, 10)
+	m.next++
+	m.store[id] = jsonID
+	return id
+}
+
+// Resolve returns the original JSON-RPC id for the correlation id.
+// If found, the mapping is removed.
+func (m *IDMapper) Resolve(corrID string) (json.RawMessage, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	jsonID, ok := m.store[corrID]
+	if ok {
+		delete(m.store, corrID)
+	}
+	return jsonID, ok
+}

--- a/internal/mcpbridge/idmap_test.go
+++ b/internal/mcpbridge/idmap_test.go
@@ -1,0 +1,35 @@
+package mcpbridge
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestIDMapper(t *testing.T) {
+	m := NewIDMapper()
+	orig := json.RawMessage(`"abc"`)
+	corr := m.Alloc(orig)
+	if corr == "" {
+		t.Fatal("empty corr id")
+	}
+	got, ok := m.Resolve(corr)
+	if !ok {
+		t.Fatal("id not found")
+	}
+	if string(got) != string(orig) {
+		t.Fatalf("expected %s got %s", orig, got)
+	}
+	if _, ok := m.Resolve(corr); ok {
+		t.Fatal("mapping should be removed after resolve")
+	}
+}
+
+func TestIDMapperNumericID(t *testing.T) {
+	m := NewIDMapper()
+	orig := json.RawMessage(`123`)
+	corr := m.Alloc(orig)
+	got, ok := m.Resolve(corr)
+	if !ok || string(got) != "123" {
+		t.Fatalf("expected 123 got %s ok=%v", got, ok)
+	}
+}


### PR DESCRIPTION
## Summary
- ADR for MCP ingress websocket frame and correlation ID mapping
- Introduce `mcpbridge` package with frame types and ID mapper
- Tests for correlation mapping and payload round-trip

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689fab224e58832cba87ce868824e5c1