### PR TITLE
fix: update wix CLI defines in Windows workflow

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -54,10 +54,10 @@ jobs:
         run: |
           New-Item -ItemType Directory -Path build | Out-Null
           wix build desktop/windows/Installer/Product.wxs `
-            -dWorkerExe="cmd\llamapool-worker\llamapool-worker.exe" `
-            -dServiceExe="desktop\windows\WindowsService\bin\Release\net8.0-windows\WindowsService.exe" `
-            -dTrayExe="desktop\windows\TrayApp\bin\Release\net8.0-windows\TrayApp.exe" `
-            -dDefaultConfig="desktop\windows\Installer\worker.yaml" `
+            -d:WorkerExe="cmd\llamapool-worker\llamapool-worker.exe" `
+            -d:ServiceExe="desktop\windows\WindowsService\bin\Release\net8.0-windows\WindowsService.exe" `
+            -d:TrayExe="desktop\windows\TrayApp\bin\Release\net8.0-windows\TrayApp.exe" `
+            -d:DefaultConfig="desktop\windows\Installer\worker.yaml" `
             -out build\llamapool.msi
 
       - name: Restore PFX from secret


### PR DESCRIPTION
## Summary
- pass WiX preprocessor variables using `-d:` syntax to match WiX v6

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689fadfe0e80832c839cfadbe22f9df8