### PR TITLE
Add chaos testing and documentation for MCP client

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ In addition to LLM workers, llamapool now supports relaying [Model Context Proto
 
 `llamapool-mcp` reads configuration from a YAML file when `MCP_CONFIG_FILE` is set. Values in the file—such as transport order, protocol version preference, or stdio working directory—are used as defaults and can be overridden by environment variables or CLI flags (e.g. `--mcp-http-url`, `--mcp-stdio-workdir`).
 
+For transport configuration, common errors, and developer guidance see [doc/mcpclient.md](doc/mcpclient.md).
+
 A typical deployment looks like this:
 
 - **`llamapool-server`** is deployed to a public or semi-public location (e.g., Azure, GCP, AWS, or a self-hosted server with dynamic DNS).

--- a/doc/mcpclient.md
+++ b/doc/mcpclient.md
@@ -1,0 +1,44 @@
+# MCP Client Guide
+
+This guide covers operation and development of the **llamapool-mcp** connector which bridges `llamapool-server` to third-party Model Context Protocol (MCP) providers.
+
+## Operator Guide
+
+The client tries transports in order until one initializes successfully. Configure the order and options via environment variables or YAML config:
+
+| Transport | Key settings |
+|-----------|--------------|
+| stdio | `MCP_STDIO_COMMAND`, `MCP_STDIO_ARGS`, `MCP_STDIO_WORKDIR` |
+| HTTP | `MCP_HTTP_URL`, `MCP_HTTP_TIMEOUT` |
+| OAuth HTTP | enable with `MCP_OAUTH_ENABLED`, set `MCP_OAUTH_CLIENT_ID`, `MCP_OAUTH_TOKEN_URL`, `MCP_OAUTH_SCOPES`, and optionally `MCP_OAUTH_TOKEN_FILE` |
+| Legacy SSE | enable with `MCP_ENABLE_LEGACY_SSE=true` |
+
+Common errors and remedies:
+
+- **405 on POST** – the provider does not support streamable HTTP.
+- **MCP_PROVIDER_UNAVAILABLE** – the relay cannot reach the provider or the process exited.
+- **TLS verification error** – set `MCP_HTTP_INSECURE_SKIP_VERIFY=true` only for testing.
+
+## Developer Notes
+
+`internal/mcpclient` defines a transport-agnostic `Connector` interface:
+
+```go
+Start(ctx context.Context) error
+Initialize(ctx context.Context, req mcp.InitializeRequest) (*mcp.InitializeResult, error)
+DoRPC(ctx context.Context, method string, params any, result any) error
+Close() error
+```
+
+The `Orchestrator` tries each transport factory in `Config.Order` with exponential backoff. To add a new transport, implement a constructor returning `*transportConnector` and register it in `NewOrchestrator`.
+
+Run the compatibility and chaos test matrix locally with:
+
+```bash
+go test ./internal/mcpclient -run Compatibility
+```
+
+## Compatibility
+
+By default the client attempts stdio and streamable HTTP transports. OAuth is used when enabled. Legacy SSE support is behind the `MCP_ENABLE_LEGACY_SSE` flag and is disabled by default.
+

--- a/internal/mcpclient/chaos_test.go
+++ b/internal/mcpclient/chaos_test.go
@@ -1,0 +1,70 @@
+package mcpclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// TestChaosHTTP verifies the client recovers from HTTP failures without leaking resources.
+func TestChaosHTTP(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		switch n {
+		case 1:
+			// immediate 5xx
+			w.WriteHeader(http.StatusInternalServerError)
+		case 2:
+			// stall until client timeout
+			time.Sleep(150 * time.Millisecond)
+		default:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"%s"}}`, mcp.LATEST_PROTOCOL_VERSION)
+		}
+	}))
+	defer srv.Close()
+
+	cfg := Config{Order: []string{"http"}, InitTimeout: 100 * time.Millisecond}
+	cfg.HTTP.URL = srv.URL
+	cfg.HTTP.Timeout = 100 * time.Millisecond
+
+	before := runtime.NumGoroutine()
+
+	// first attempt -> 5xx
+	if _, err := NewOrchestrator(cfg).Connect(context.Background()); err == nil {
+		t.Fatalf("expected error on 5xx")
+	}
+
+	// second attempt -> timeout
+	if _, err := NewOrchestrator(cfg).Connect(context.Background()); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context deadline exceeded, got %v", err)
+	}
+
+	// third attempt -> success
+	cfg.InitTimeout = time.Second
+	cfg.HTTP.Timeout = time.Second
+	conn, err := NewOrchestrator(cfg).Connect(context.Background())
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	if err := conn.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	// allow goroutines to settle
+	time.Sleep(100 * time.Millisecond)
+	runtime.GC()
+	after := runtime.NumGoroutine()
+	if after-before > 5 {
+		t.Fatalf("possible goroutine leak: before=%d after=%d", before, after)
+	}
+}


### PR DESCRIPTION
## Summary
- Add chaos-mode HTTP failure test covering 5xx and stall scenarios with leak checks
- Document MCP client configuration and developer workflow
- Link MCP client guide from README

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689fb848ffc8832c9e25c21ccf82ac56