### PR TITLE
Improve state dashboard and worker metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The Windows service runs `llamapool-worker` with the `--reconnect` flag and shut
   - Swagger UI: `GET /api/client/`
   - OpenAPI schema: `GET /api/client/openapi.json`
   - Update schema: edit `api/openapi.yaml` then run `make generate`
-- Web dashboard: `GET /state` (real-time view of workers)
+- Web dashboard: `GET /state` (real-time view of workers with names, status indicators and sortable columns)
 
 
 ## Security

--- a/internal/api/state_test.go
+++ b/internal/api/state_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestGetState(t *testing.T) {
 	metricsReg := ctrl.NewMetricsRegistry("v", "sha", "date")
-	metricsReg.UpsertWorker("w1", "1", "a", "d", []string{"m"})
+	metricsReg.UpsertWorker("w1", "w1", "1", "a", "d", 1, []string{"m"})
 	metricsReg.SetWorkerStatus("w1", ctrl.StatusConnected)
 	metricsReg.RecordJobStart("w1")
 	metricsReg.RecordJobEnd("w1", "m", 50*time.Millisecond, 5, 7, true, "")
@@ -30,6 +30,9 @@ func TestGetState(t *testing.T) {
 	}
 	if len(resp.Workers) != 1 || resp.Server.JobsCompletedTotal != 1 {
 		t.Fatalf("bad response %+v", resp)
+	}
+	if resp.Workers[0].Name != "w1" {
+		t.Fatalf("expected worker name")
 	}
 }
 

--- a/internal/ctrl/metrics.go
+++ b/internal/ctrl/metrics.go
@@ -1,6 +1,7 @@
 package ctrl
 
 import (
+	"sort"
 	"sync"
 	"time"
 )
@@ -26,6 +27,7 @@ type PerModelStats struct {
 // WorkerSnapshot represents a snapshot of worker metrics.
 type WorkerSnapshot struct {
 	ID                string                   `json:"id"`
+	Name              string                   `json:"name"`
 	Status            WorkerStatus             `json:"status"`
 	ConnectedAt       time.Time                `json:"connected_at"`
 	LastHeartbeat     time.Time                `json:"last_heartbeat"`
@@ -33,6 +35,7 @@ type WorkerSnapshot struct {
 	BuildSHA          string                   `json:"build_sha,omitempty"`
 	BuildDate         string                   `json:"build_date,omitempty"`
 	ModelsSupported   []string                 `json:"models_supported"`
+	MaxConcurrency    int                      `json:"max_concurrency"`
 	ProcessedTotal    uint64                   `json:"processed_total"`
 	ProcessingMsTotal uint64                   `json:"processing_ms_total"`
 	AvgProcessingMs   float64                  `json:"avg_processing_ms"`
@@ -99,6 +102,7 @@ type MetricsRegistry struct {
 
 type workerMetrics struct {
 	id              string
+	name            string
 	status          WorkerStatus
 	connectedAt     time.Time
 	lastHeartbeat   time.Time
@@ -106,6 +110,7 @@ type workerMetrics struct {
 	buildSHA        string
 	buildDate       string
 	modelsSupported []string
+	maxConcurrency  int
 
 	processedTotal    uint64
 	processingMsTotal uint64
@@ -132,7 +137,7 @@ func NewMetricsRegistry(serverVersion, serverSHA, serverDate string) *MetricsReg
 }
 
 // UpsertWorker registers or updates a worker.
-func (m *MetricsRegistry) UpsertWorker(id, version, buildSHA, buildDate string, models []string) {
+func (m *MetricsRegistry) UpsertWorker(id, name, version, buildSHA, buildDate string, maxConcurrency int, models []string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	w, ok := m.workers[id]
@@ -140,14 +145,23 @@ func (m *MetricsRegistry) UpsertWorker(id, version, buildSHA, buildDate string, 
 		w = &workerMetrics{id: id, connectedAt: time.Now(), perModel: make(map[string]*PerModelStats)}
 		m.workers[id] = w
 	}
+	w.name = name
 	w.version = version
 	w.buildSHA = buildSHA
 	w.buildDate = buildDate
 	w.modelsSupported = models
+	w.maxConcurrency = maxConcurrency
 	w.lastHeartbeat = time.Now()
 	if w.status == "" {
 		w.status = StatusConnected
 	}
+}
+
+// RemoveWorker deletes a worker from the registry.
+func (m *MetricsRegistry) RemoveWorker(id string) {
+	m.mu.Lock()
+	delete(m.workers, id)
+	m.mu.Unlock()
 }
 
 // SetWorkerStatus sets the status of a worker.
@@ -276,7 +290,14 @@ func (m *MetricsRegistry) Snapshot() StateResponse {
 	}
 
 	modelWorkers := make(map[string]int)
+	workers := make([]*workerMetrics, 0, len(m.workers))
 	for _, w := range m.workers {
+		workers = append(workers, w)
+	}
+	sort.Slice(workers, func(i, j int) bool {
+		return workers[i].connectedAt.Before(workers[j].connectedAt)
+	})
+	for _, w := range workers {
 		switch w.status {
 		case StatusConnected:
 			resp.WorkersSummary.Connected++
@@ -284,8 +305,6 @@ func (m *MetricsRegistry) Snapshot() StateResponse {
 			resp.WorkersSummary.Working++
 		case StatusIdle:
 			resp.WorkersSummary.Idle++
-		case StatusGone:
-			resp.WorkersSummary.Gone++
 		}
 		for _, mname := range w.modelsSupported {
 			modelWorkers[mname]++
@@ -300,6 +319,7 @@ func (m *MetricsRegistry) Snapshot() StateResponse {
 		}
 		snapshot := WorkerSnapshot{
 			ID:                w.id,
+			Name:              w.name,
 			Status:            w.status,
 			ConnectedAt:       w.connectedAt,
 			LastHeartbeat:     w.lastHeartbeat,
@@ -307,6 +327,7 @@ func (m *MetricsRegistry) Snapshot() StateResponse {
 			BuildSHA:          w.buildSHA,
 			BuildDate:         w.buildDate,
 			ModelsSupported:   append([]string(nil), w.modelsSupported...),
+			MaxConcurrency:    w.maxConcurrency,
 			ProcessedTotal:    w.processedTotal,
 			ProcessingMsTotal: w.processingMsTotal,
 			AvgProcessingMs:   avg,
@@ -321,8 +342,13 @@ func (m *MetricsRegistry) Snapshot() StateResponse {
 		resp.Workers = append(resp.Workers, snapshot)
 	}
 
-	for name, count := range modelWorkers {
-		resp.Models = append(resp.Models, ModelCount{Name: name, Workers: count})
+	modelNames := make([]string, 0, len(modelWorkers))
+	for name := range modelWorkers {
+		modelNames = append(modelNames, name)
+	}
+	sort.Strings(modelNames)
+	for _, name := range modelNames {
+		resp.Models = append(resp.Models, ModelCount{Name: name, Workers: modelWorkers[name]})
 	}
 
 	return resp

--- a/internal/ctrl/ws.go
+++ b/internal/ctrl/ws.go
@@ -72,12 +72,12 @@ func WSHandler(reg *Registry, metrics *MetricsRegistry, workerKey string) http.H
 			wk.Models[m] = true
 		}
 		reg.Add(wk)
-		metrics.UpsertWorker(wk.ID, rm.Version, rm.BuildSHA, rm.BuildDate, rm.Models)
+		metrics.UpsertWorker(wk.ID, wk.Name, rm.Version, rm.BuildSHA, rm.BuildDate, rm.MaxConcurrency, rm.Models)
 		metrics.SetWorkerStatus(wk.ID, StatusIdle)
 		logx.Log.Info().Str("worker_id", wk.ID).Str("worker_name", wk.Name).Int("model_count", len(wk.Models)).Msg("registered")
 		defer func() {
 			reg.Remove(wk.ID)
-			metrics.SetWorkerStatus(wk.ID, StatusGone)
+			metrics.RemoveWorker(wk.ID)
 		}()
 
 		go func() {

--- a/internal/server/state.html
+++ b/internal/server/state.html
@@ -37,6 +37,7 @@ h1 {
   gap: 1rem;
 }
 .worker {
+  position: relative;
   border: 1px solid var(--box-border);
   border-radius: 8px;
   padding: 0.5rem 1rem;
@@ -50,6 +51,27 @@ h1 {
   font-weight: bold;
   margin-top: 0.5rem;
 }
+.worker .status-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  display: inline-block;
+  margin-right: 0.5rem;
+}
+.busy-bar {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 4px;
+  background: var(--box-border);
+}
+.busy-bar .fill {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  background: #0af;
+}
 @media (max-width: 600px) {
   #workers { flex-direction: column; }
 }
@@ -58,20 +80,77 @@ h1 {
 <body>
 <h1>llamapool state</h1>
 <div id="summary">Loading…</div>
+<div>Sort by: <select id="sort">
+  <option value="oldest">Oldest</option>
+  <option value="youngest">Youngest</option>
+  <option value="busyness">Busyness</option>
+  <option value="name">Name</option>
+  <option value="completed">Completed</option>
+  <option value="errors">Errors</option>
+</select></div>
 <div id="workers"></div>
 <script>
-function update(data) {
-  const sum = data.workers_summary;
-  document.getElementById('summary').textContent = `Workers: ${sum.connected} connected, ${sum.working} working, ${sum.idle} idle`;
+let workers = [];
+let sortBy = 'oldest';
+
+function render() {
   const container = document.getElementById('workers');
   container.innerHTML = '';
-  data.workers.forEach(w => {
+  const list = workers.slice();
+  list.sort((a, b) => {
+    switch (sortBy) {
+      case 'youngest':
+        return new Date(b.connected_at) - new Date(a.connected_at);
+      case 'busyness':
+        const ba = (a.inflight + a.queue_len) / (a.max_concurrency || 1);
+        const bb = (b.inflight + b.queue_len) / (b.max_concurrency || 1);
+        return bb - ba;
+      case 'name':
+        return (a.name || '').localeCompare(b.name || '');
+      case 'completed':
+        return b.processed_total - a.processed_total;
+      case 'errors':
+        return b.failures_total - a.failures_total;
+      case 'oldest':
+      default:
+        return new Date(a.connected_at) - new Date(b.connected_at);
+    }
+  });
+  list.forEach(w => {
     const div = document.createElement('div');
     div.className = 'worker';
-    div.innerHTML = `<div class="emoji">🦙</div><div class="name">${w.id}</div><div>${w.status}</div><div>inflight: ${w.inflight}</div>`;
+    const status = statusColor(w);
+    const busy = Math.min(1, (w.inflight + w.queue_len) / (w.max_concurrency || 1));
+    div.innerHTML = `
+      <div class="busy-bar"><div class="fill" style="height:${busy*100}%"></div></div>
+      <div class="emoji">🦙</div>
+      <div class="name"><span class="status-dot" style="background:${status}"></span>${w.name || w.id}</div>
+      <div>${w.status}</div>
+      <div>inflight: ${w.inflight}</div>
+    `;
     container.appendChild(div);
   });
 }
+
+function update(data) {
+  const sum = data.workers_summary;
+  document.getElementById('summary').textContent = `Workers: ${sum.connected} connected, ${sum.working} working, ${sum.idle} idle`;
+  workers = data.workers;
+  render();
+}
+
+function statusColor(w) {
+  if (w.last_error) return 'red';
+  if (Date.now() - new Date(w.last_heartbeat).getTime() > 15000) return 'orange';
+  if (w.inflight > 0) return 'gold';
+  return 'green';
+}
+
+document.getElementById('sort').addEventListener('change', (e) => {
+  sortBy = e.target.value;
+  render();
+});
+
 const es = new EventSource('/api/state/stream');
 es.onmessage = (e) => {
   try {


### PR DESCRIPTION
## Summary
- show worker names and max concurrency in state metrics
- drop disconnected workers and sort workers by age
- enhance `/state` dashboard with sort options and status indicators

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689fdb5ccc14832caa749d462a22e299