### PR TITLE
mcpclient: add websocket proxy harness

### DIFF
--- a/internal/mcpclient/connector.go
+++ b/internal/mcpclient/connector.go
@@ -29,6 +29,9 @@ type Connector interface {
 	Protocol() string
 	Features() Features
 	Close() error
+	// Transport returns the underlying transport.Interface.
+	// It enables low-level JSON-RPC forwarding without interpretation.
+	Transport() transport.Interface
 }
 
 // transportConnector wraps a transport.Interface to satisfy Connector.
@@ -107,6 +110,7 @@ func (c *transportConnector) DoRPC(ctx context.Context, method string, params an
 func (c *transportConnector) Capabilities() mcp.ServerCapabilities { return c.serverCaps }
 func (c *transportConnector) Protocol() string                     { return c.protocol }
 func (c *transportConnector) Features() Features                   { return c.features }
+func (c *transportConnector) Transport() transport.Interface       { return c.t }
 
 // Constructors for specific transports
 

--- a/internal/mcpclient/proxy.go
+++ b/internal/mcpclient/proxy.go
@@ -1,0 +1,109 @@
+package mcpclient
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+
+	"github.com/coder/websocket"
+	"github.com/mark3labs/mcp-go/client/transport"
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/gaspardpetit/llamapool/internal/mcpbridge"
+)
+
+// wsConn abstracts a minimal websocket connection for testing.
+type wsConn interface {
+	Read(ctx context.Context) (websocket.MessageType, []byte, error)
+	Write(ctx context.Context, typ websocket.MessageType, data []byte) error
+}
+
+// ConnectorFactory creates a Connector for a session.
+type ConnectorFactory func(ctx context.Context, sessionID string) (Connector, error)
+
+// Proxy bridges websocket frames to a third-party MCP server via mcp-go transports.
+type Proxy struct {
+	conn     wsConn
+	factory  ConnectorFactory
+	mu       sync.Mutex
+	sessions map[string]Connector
+}
+
+// NewProxy constructs a Proxy using the given websocket connection and factory.
+func NewProxy(conn wsConn, factory ConnectorFactory) *Proxy {
+	return &Proxy{conn: conn, factory: factory, sessions: map[string]Connector{}}
+}
+
+// Run processes frames until the connection errors.
+func (p *Proxy) Run(ctx context.Context) error {
+	for {
+		_, data, err := p.conn.Read(ctx)
+		if err != nil {
+			return err
+		}
+		var f mcpbridge.Frame
+		if json.Unmarshal(data, &f) != nil {
+			continue
+		}
+		if err := p.handleFrame(ctx, f); err != nil {
+			return err
+		}
+	}
+}
+
+func (p *Proxy) handleFrame(ctx context.Context, f mcpbridge.Frame) error {
+	conn, err := p.getSession(ctx, f.SessionID)
+	if err != nil {
+		return err
+	}
+	t := conn.Transport()
+	switch f.Type {
+	case mcpbridge.TypeRequest:
+		var req transport.JSONRPCRequest
+		if err := json.Unmarshal(f.Payload, &req); err != nil {
+			return err
+		}
+		resp, err := t.SendRequest(ctx, req)
+		if err != nil {
+			return err
+		}
+		b, _ := json.Marshal(resp)
+		out := mcpbridge.Frame{Type: mcpbridge.TypeResponse, ID: f.ID, SessionID: f.SessionID, Payload: b}
+		ob, _ := json.Marshal(out)
+		return p.conn.Write(ctx, websocket.MessageText, ob)
+	case mcpbridge.TypeNotification:
+		var n mcp.JSONRPCNotification
+		if err := json.Unmarshal(f.Payload, &n); err != nil {
+			return err
+		}
+		return t.SendNotification(ctx, n)
+	}
+	return nil
+}
+
+func (p *Proxy) getSession(ctx context.Context, id string) (Connector, error) {
+	p.mu.Lock()
+	conn := p.sessions[id]
+	p.mu.Unlock()
+	if conn != nil {
+		return conn, nil
+	}
+	if p.factory == nil {
+		return nil, context.Canceled
+	}
+	c, err := p.factory(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	t := c.Transport()
+	t.SetNotificationHandler(func(n mcp.JSONRPCNotification) {
+		b, _ := json.Marshal(n)
+		f := mcpbridge.Frame{Type: mcpbridge.TypeNotification, SessionID: id, Payload: b}
+		ob, _ := json.Marshal(f)
+		_ = p.conn.Write(context.Background(), websocket.MessageText, ob)
+	})
+	p.mu.Lock()
+	p.sessions[id] = c
+	p.mu.Unlock()
+	return c, nil
+}

--- a/internal/mcpclient/proxy_test.go
+++ b/internal/mcpclient/proxy_test.go
@@ -1,0 +1,78 @@
+package mcpclient
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/coder/websocket"
+	"github.com/mark3labs/mcp-go/client/transport"
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/gaspardpetit/llamapool/internal/mcpbridge"
+)
+
+type fakeWSConn struct {
+	writeCh chan []byte
+}
+
+func (f *fakeWSConn) Read(ctx context.Context) (websocket.MessageType, []byte, error) {
+	return 0, nil, context.Canceled
+}
+
+func (f *fakeWSConn) Write(ctx context.Context, typ websocket.MessageType, data []byte) error {
+	f.writeCh <- data
+	return nil
+}
+
+type proxyTransport struct {
+	lastReq transport.JSONRPCRequest
+	resp    transport.JSONRPCResponse
+}
+
+func (f *proxyTransport) Start(context.Context) error { return nil }
+func (f *proxyTransport) SendRequest(ctx context.Context, req transport.JSONRPCRequest) (*transport.JSONRPCResponse, error) {
+	f.lastReq = req
+	return &f.resp, nil
+}
+func (f *proxyTransport) SendNotification(context.Context, mcp.JSONRPCNotification) error { return nil }
+func (f *proxyTransport) SetNotificationHandler(func(mcp.JSONRPCNotification))            {}
+func (f *proxyTransport) Close() error                                                    { return nil }
+func (f *proxyTransport) GetSessionId() string                                            { return "" }
+
+func TestProxyHandleRequest(t *testing.T) {
+	reqJSON := []byte(`{"jsonrpc":"2.0","id":1,"method":"test","params":{"a":1}}`)
+	resp := transport.JSONRPCResponse{JSONRPC: "2.0", ID: mcp.NewRequestId(1), Result: json.RawMessage(`{"ok":true}`)}
+	ft := &proxyTransport{resp: resp}
+	conn := newTransportConnector(ft, 0)
+	ws := &fakeWSConn{writeCh: make(chan []byte, 1)}
+	p := &Proxy{conn: ws, sessions: map[string]Connector{"sess": conn}}
+
+	frame := mcpbridge.Frame{Type: mcpbridge.TypeRequest, ID: "corr", SessionID: "sess", Payload: reqJSON}
+	if err := p.handleFrame(context.Background(), frame); err != nil {
+		t.Fatalf("handle: %v", err)
+	}
+	gotReqBytes, _ := json.Marshal(ft.lastReq)
+	var gotReq, wantReq map[string]any
+	_ = json.Unmarshal(gotReqBytes, &gotReq)
+	_ = json.Unmarshal(reqJSON, &wantReq)
+	if !reflect.DeepEqual(gotReq, wantReq) {
+		t.Fatalf("request mismatch: %v vs %v", gotReq, wantReq)
+	}
+	outBytes := <-ws.writeCh
+	var outFrame mcpbridge.Frame
+	if err := json.Unmarshal(outBytes, &outFrame); err != nil {
+		t.Fatalf("unmarshal frame: %v", err)
+	}
+	if outFrame.ID != frame.ID {
+		t.Fatalf("corr id mismatch got %s want %s", outFrame.ID, frame.ID)
+	}
+	var gotResp, wantResp map[string]any
+	_ = json.Unmarshal(outFrame.Payload, &gotResp)
+	respBytes, _ := json.Marshal(resp)
+	_ = json.Unmarshal(respBytes, &wantResp)
+	if !reflect.DeepEqual(gotResp, wantResp) {
+		t.Fatalf("response mismatch: %v vs %v", gotResp, wantResp)
+	}
+}


### PR DESCRIPTION
## Summary
- expose underlying transport on MCP connectors
- add Proxy to forward websocket frames to an MCP transport
- cover request forwarding with unit test

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689fe0d20824832cb1546560a73cf832