### PR TITLE
mcp: track sessions and improve health

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,8 @@ The server also exposes a basic health check:
 curl http://localhost:8080/healthz
 ```
 
+The endpoint reports `503 Service Unavailable` if no MCP session is ready.
+
 For server administration and monitoring:
 
 ```bash

--- a/internal/api/impl_test.go
+++ b/internal/api/impl_test.go
@@ -1,0 +1,25 @@
+package api
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+type fakeHealth struct{ ok bool }
+
+func (f fakeHealth) Healthy() bool { return f.ok }
+
+func TestGetHealthz(t *testing.T) {
+	api := &API{Health: fakeHealth{ok: false}}
+	rr := httptest.NewRecorder()
+	api.GetHealthz(rr, httptest.NewRequest("GET", "/healthz", nil))
+	if rr.Code != 503 {
+		t.Fatalf("want 503 got %d", rr.Code)
+	}
+	api.Health = fakeHealth{ok: true}
+	rr = httptest.NewRecorder()
+	api.GetHealthz(rr, httptest.NewRequest("GET", "/healthz", nil))
+	if rr.Code != 200 {
+		t.Fatalf("want 200 got %d", rr.Code)
+	}
+}

--- a/internal/mcpbridge/bridge.go
+++ b/internal/mcpbridge/bridge.go
@@ -72,6 +72,13 @@ func NewBridge(url string, maxInflight int) *Bridge {
 	return &Bridge{url: url, maxInflight: maxInflight, sessions: map[string]*session{}, serverReqCh: make(chan ServerRequest, maxInflight)}
 }
 
+// Healthy reports whether any sessions are active.
+func (b *Bridge) Healthy() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.sessions) > 0
+}
+
 // Forward sends a JSON-RPC request payload over the bridge and waits for the response.
 func (b *Bridge) Forward(ctx context.Context, sessionID string, payload json.RawMessage, jsonID json.RawMessage, stream func(json.RawMessage)) (json.RawMessage, error) {
 	sess, err := b.getSession(ctx, sessionID)

--- a/internal/mcpbridge/bridge_test.go
+++ b/internal/mcpbridge/bridge_test.go
@@ -195,3 +195,10 @@ func TestBridgeServerRequest(t *testing.T) {
 	}
 	br.Close()
 }
+
+func TestBridgeHealthy(t *testing.T) {
+	br := NewBridge("ws://example", 1)
+	if br.Healthy() {
+		t.Fatalf("expected unhealthy")
+	}
+}

--- a/internal/mcpclient/connector.go
+++ b/internal/mcpclient/connector.go
@@ -28,6 +28,7 @@ type Connector interface {
 	Capabilities() mcp.ServerCapabilities
 	Protocol() string
 	Features() Features
+	SessionID() string
 	Close() error
 	// Transport returns the underlying transport.Interface.
 	// It enables low-level JSON-RPC forwarding without interpretation.
@@ -41,6 +42,7 @@ type transportConnector struct {
 	serverCaps mcp.ServerCapabilities
 	protocol   string
 	features   Features
+	sessionID  string
 	sem        chan struct{}
 }
 
@@ -53,7 +55,21 @@ func newTransportConnector(t transport.Interface, maxInFlight int) *transportCon
 }
 
 func (c *transportConnector) Start(ctx context.Context) error {
-	return c.t.Start(ctx)
+	if err := c.t.Start(ctx); err != nil {
+		return err
+	}
+	type connectionLostSetter interface{ SetConnectionLostHandler(func(error)) }
+	if setter, ok := c.t.(connectionLostSetter); ok {
+		setter.SetConnectionLostHandler(func(err error) {
+			logx.Log.Warn().Err(err).Msg("downstream connection lost")
+			go func() {
+				if err := c.t.Start(context.Background()); err != nil {
+					logx.Log.Error().Err(err).Msg("reconnect failed")
+				}
+			}()
+		})
+	}
+	return nil
 }
 
 func (c *transportConnector) Close() error { return c.t.Close() }
@@ -78,6 +94,7 @@ func (c *transportConnector) Initialize(ctx context.Context, req mcp.InitializeR
 	c.serverCaps = res.Capabilities
 	c.protocol = res.ProtocolVersion
 	c.features = deriveFeatures(res.Capabilities)
+	c.sessionID = c.t.GetSessionId()
 	// best effort notification
 	_ = c.t.SendNotification(ctx, mcp.JSONRPCNotification{JSONRPC: mcp.JSONRPC_VERSION, Notification: mcp.Notification{Method: "notifications/initialized"}})
 	return &res, nil
@@ -110,6 +127,7 @@ func (c *transportConnector) DoRPC(ctx context.Context, method string, params an
 func (c *transportConnector) Capabilities() mcp.ServerCapabilities { return c.serverCaps }
 func (c *transportConnector) Protocol() string                     { return c.protocol }
 func (c *transportConnector) Features() Features                   { return c.features }
+func (c *transportConnector) SessionID() string                    { return c.sessionID }
 func (c *transportConnector) Transport() transport.Interface       { return c.t }
 
 // Constructors for specific transports

--- a/internal/mcpclient/orchestrator.go
+++ b/internal/mcpclient/orchestrator.go
@@ -76,7 +76,12 @@ func (o *Orchestrator) Connect(ctx context.Context) (Connector, error) {
 		if conn.Protocol() != version {
 			o.log.Warn().Str("transport", name).Str("server_protocol", conn.Protocol()).Str("client_protocol", version).Msg("protocol downgraded")
 		}
-		o.log.Info().Str("transport", name).Msg("connected")
+		o.log.Info().
+			Str("transport", name).
+			Str("session", conn.SessionID()).
+			Str("protocol", conn.Protocol()).
+			Interface("capabilities", conn.Capabilities()).
+			Msg("connected")
 		return conn, nil
 	}
 	return nil, errors.Join(errs...)


### PR DESCRIPTION
## Summary
- track MCP session IDs and restart transports on connection loss
- surface session and capability details during initialization
- expose relay health via API and document /healthz behavior

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a084dbd5dc832caf6db816e192015c