### PR TITLE
Fix test flakiness and race conditions

### DIFF
--- a/internal/ctrl/models.go
+++ b/internal/ctrl/models.go
@@ -17,6 +17,7 @@ func (r *Registry) AggregatedModels() []ModelInfo {
 	defer r.mu.RUnlock()
 	m := make(map[string]*ModelInfo)
 	for _, w := range r.workers {
+		w.mu.Lock()
 		for id := range w.Models {
 			info, ok := m[id]
 			if !ok {
@@ -25,6 +26,7 @@ func (r *Registry) AggregatedModels() []ModelInfo {
 			}
 			info.Owners = append(info.Owners, w.Name)
 		}
+		w.mu.Unlock()
 	}
 	var res []ModelInfo
 	for _, info := range m {
@@ -41,9 +43,11 @@ func (r *Registry) AggregatedModel(id string) (ModelInfo, bool) {
 	defer r.mu.RUnlock()
 	var owners []string
 	for _, w := range r.workers {
+		w.mu.Lock()
 		if w.Models[id] {
 			owners = append(owners, w.Name)
 		}
+		w.mu.Unlock()
 	}
 	if len(owners) == 0 {
 		return ModelInfo{}, false

--- a/internal/mcpclient/compat_test.go
+++ b/internal/mcpclient/compat_test.go
@@ -151,7 +151,7 @@ func main(){
 	if err := os.WriteFile(path, []byte(program), 0600); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	cfg := Config{Order: []string{"stdio"}, InitTimeout: 5 * time.Second}
+	cfg := Config{Order: []string{"stdio"}, InitTimeout: 30 * time.Second}
 	cfg.Stdio.Command = "go"
 	cfg.Stdio.Args = []string{"run", path}
 	cfg.Stdio.AllowRelative = true

--- a/internal/mcpclient/orchestrator_test.go
+++ b/internal/mcpclient/orchestrator_test.go
@@ -109,12 +109,12 @@ func main(){
 	if err := os.WriteFile(path, []byte(program), 0600); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	cfg := Config{Order: []string{"stdio"}, InitTimeout: 20 * time.Second}
+	cfg := Config{Order: []string{"stdio"}, InitTimeout: 40 * time.Second}
 	cfg.Stdio.Command = "go"
 	cfg.Stdio.Args = []string{"run", path}
 	cfg.Stdio.AllowRelative = true
 	o := NewOrchestrator(cfg)
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
 	defer cancel()
 	conn, err := o.Connect(ctx)
 	if err != nil {

--- a/internal/worker/drain_integration_test.go
+++ b/internal/worker/drain_integration_test.go
@@ -123,7 +123,7 @@ func TestDrainAndTerminate(t *testing.T) {
 		if err != nil {
 			t.Fatalf("run error: %v", err)
 		}
-	case <-time.After(2 * time.Second):
+	case <-time.After(5 * time.Second):
 		t.Fatalf("timeout waiting for worker exit")
 	}
 }
@@ -171,7 +171,7 @@ func TestDrainTerminatesWhenIdle(t *testing.T) {
 		if err != nil {
 			t.Fatalf("run error: %v", err)
 		}
-	case <-time.After(3 * time.Second):
+	case <-time.After(10 * time.Second):
 		t.Fatalf("timeout waiting for worker exit")
 	}
 }

--- a/internal/worker/drain_integration_test.go
+++ b/internal/worker/drain_integration_test.go
@@ -171,7 +171,7 @@ func TestDrainTerminatesWhenIdle(t *testing.T) {
 		if err != nil {
 			t.Fatalf("run error: %v", err)
 		}
-	case <-time.After(time.Second):
+	case <-time.After(3 * time.Second):
 		t.Fatalf("timeout waiting for worker exit")
 	}
 }

--- a/internal/worker/health_test.go
+++ b/internal/worker/health_test.go
@@ -55,7 +55,8 @@ func TestProbeOllamaUpdatesState(t *testing.T) {
 
 func TestProbeOllamaSendsUpdates(t *testing.T) {
 	resetState()
-	SetModels([]string{"m1"})
+	SetWorkerInfo("w1", "n", 1, []string{"m1"})
+	SetConnectedToOllama(true)
 	cfg := config.WorkerConfig{WorkerID: "w1", WorkerName: "n", MaxConcurrency: 1}
 
 	// We now use the status update channel, and probeOllama only emits when something changes.

--- a/internal/worker/status.go
+++ b/internal/worker/status.go
@@ -37,9 +37,10 @@ var (
 
 func resetState() {
 	stateMu.Lock()
-	defer stateMu.Unlock()
 	stateData = State{State: "disconnected"}
+	stateMu.Unlock()
 	draining.Store(false)
+	setDrainCheck(nil)
 }
 
 func SetBuildInfo(v, sha, date string) {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -34,11 +34,11 @@ func Run(ctx context.Context, cfg config.WorkerConfig) error {
 
 	interval := cfg.ModelPollInterval
 	if interval <= 0 {
-		interval = time.Minute
+		interval = 20 * time.Second
 	}
 
 	statusUpdates := make(chan ctrl.StatusUpdateMessage, 16)
-	startOllamaMonitor(ctx, cfg, client, statusUpdates, 20*time.Second)
+	startOllamaMonitor(ctx, cfg, client, statusUpdates, interval)
 
 	if cfg.StatusAddr != "" {
 		if _, err := StartStatusServer(ctx, cfg.StatusAddr, cfg.ConfigFile, cfg.DrainTimeout, cancel); err != nil {

--- a/test/e2e_model_update_test.go
+++ b/test/e2e_model_update_test.go
@@ -70,18 +70,24 @@ func TestWorkerModelRefresh(t *testing.T) {
 		t.Fatalf("models not updated")
 	}
 
+	sm := ctrl.StatusUpdateMessage{Type: "status_update", MaxConcurrency: 1, Models: []string{"m1"}, Status: "idle"}
+	b, _ = json.Marshal(sm)
+	if err := conn.Write(ctx, websocket.MessageText, b); err != nil {
+		t.Fatalf("write status: %v", err)
+	}
+
 	waitForModels(1, "m1")
 
-	um := ctrl.ModelsUpdateMessage{Type: "models_update", Models: []string{"m1", "m2"}}
-	b, _ = json.Marshal(um)
+	sm = ctrl.StatusUpdateMessage{Type: "status_update", MaxConcurrency: 1, Models: []string{"m1", "m2"}, Status: "idle"}
+	b, _ = json.Marshal(sm)
 	if err := conn.Write(ctx, websocket.MessageText, b); err != nil {
 		t.Fatalf("write update: %v", err)
 	}
 
 	waitForModels(2, "m2")
 
-	um = ctrl.ModelsUpdateMessage{Type: "models_update", Models: []string{"m2"}}
-	b, _ = json.Marshal(um)
+	sm = ctrl.StatusUpdateMessage{Type: "status_update", MaxConcurrency: 1, Models: []string{"m2"}, Status: "idle"}
+	b, _ = json.Marshal(sm)
 	if err := conn.Write(ctx, websocket.MessageText, b); err != nil {
 		t.Fatalf("write update2: %v", err)
 	}


### PR DESCRIPTION
## Summary
- lock worker model maps during aggregation to prevent race conditions
- propagate configurable model poll interval to Ollama monitor
- stabilize MCP stdio and worker model refresh tests

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a0b18d485c832c9694b2df9dd02c4f