### PR TITLE
Add Sparkle package resolution for macOS Xcode build

### DIFF
--- a/desktop/macos/llamapool/llamapool.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/desktop/macos/llamapool/llamapool.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Sparkle",
+        "repositoryURL": "https://github.com/sparkle-project/Sparkle",
+        "state": {
+          "branch": null,
+          "revision": "0ef1ee0220239b3776f433314515fd849025673f",
+          "version": "2.6.4"
+        }
+      }
+    ]
+  },
+  "version": 2
+}


### PR DESCRIPTION
## Summary
- add Package.resolved to pin Sparkle SwiftPM dependency for macOS menu bar app

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a1fef4bc88832c84b2fad94edaac93