### PR TITLE
Add MCP proxy example with FastMCP time server

### DIFF
--- a/examples/mcp-proxy/README.md
+++ b/examples/mcp-proxy/README.md
@@ -1,0 +1,48 @@
+# MCP Proxy Example
+
+This example shows how to bridge a Python [fastmcp](https://pypi.org/project/fastmcp/) server through `llamapool-mcp` so that calls sent to `llamapool-server` are forwarded to a private MCP provider.
+
+## 1. Start the FastMCP provider
+
+```bash
+python examples/mcp-proxy/time_server.py
+```
+
+The server exposes a single tool `time/now` that returns the current ISO timestamp over HTTP on `http://127.0.0.1:7777/mcp`.
+
+## 2. Run the llamapool components
+
+In separate terminals:
+
+```bash
+# Start the public server
+env BROKER_ACCEPTED_CLIENTS=time-client BROKER_RELAY_TOKEN=secret API_KEY=test123 ./llamapool-server
+
+# Connect the MCP relay
+env BROKER_WS_URL=ws://localhost:8080/ws/relay \
+    CLIENT_ID=time-client \
+    PROVIDER_URL=http://127.0.0.1:7777/mcp \
+    RELAY_AUTH_TOKEN=secret \
+    ./llamapool-mcp
+```
+
+## 3. Invoke the tool via HTTP
+
+Initialize the MCP session:
+
+```bash
+curl -s -X POST http://localhost:8080/mcp/time-client \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"demo","version":"0.0.0"}}}'
+```
+
+Then invoke the tool:
+
+```bash
+curl -s -X POST http://localhost:8080/mcp/time-client \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"time/now","arguments":{}}}'
+```
+
+The response contains the current time string returned by the FastMCP server.

--- a/examples/mcp-proxy/time_server.py
+++ b/examples/mcp-proxy/time_server.py
@@ -1,0 +1,11 @@
+from datetime import datetime
+from fastmcp import FastMCP
+
+app = FastMCP("clock", stateless_http=True, json_response=True)
+
+@app.tool("time/now")
+def now() -> str:
+    return datetime.now().isoformat()
+
+if __name__ == "__main__":
+    app.run("http", host="127.0.0.1", port=7777)

--- a/internal/mcp/broker.go
+++ b/internal/mcp/broker.go
@@ -108,7 +108,7 @@ func (r *Registry) WSHandler() http.HandlerFunc {
 		r.mu.Lock()
 		r.relays[clientID] = relay
 		r.mu.Unlock()
-		ctx := req.Context()
+		ctx := context.Background()
 		go r.readPump(ctx, clientID, relay)
 		go r.pingLoop(ctx, clientID, relay)
 	}

--- a/internal/mcp/relay.go
+++ b/internal/mcp/relay.go
@@ -77,6 +77,7 @@ func (r *RelayClient) callProvider(ctx context.Context, payload []byte) ([]byte,
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gaspardpetit/llamapool/internal/api"
 	"github.com/gaspardpetit/llamapool/internal/config"
 	"github.com/gaspardpetit/llamapool/internal/ctrl"
+	"github.com/gaspardpetit/llamapool/internal/mcp"
 	"github.com/gaspardpetit/llamapool/internal/mcpserver"
 )
 
@@ -55,6 +56,9 @@ func New(reg *ctrl.Registry, metrics *ctrl.MetricsRegistry, sched ctrl.Scheduler
 		apiGroup.Get("/state", wrapper.GetApiState)
 		apiGroup.Get("/state/stream", wrapper.GetApiStateStream)
 	})
+	broker := mcp.NewRegistry()
+	r.Handle("/ws/relay", broker.WSHandler())
+	r.Handle("/mcp/{client_id}", broker.HTTPHandler())
 	r.Mount("/mcp", mcpserver.NewHandler())
 	r.Handle("/api/workers/connect", ctrl.WSHandler(reg, metrics, cfg.WorkerKey))
 


### PR DESCRIPTION
## Summary
- Expose MCP relay endpoints in server and keep websocket relays alive
- Forward `Accept` header when proxying to upstream MCP providers
- Document initializing an MCP session before invoking the `time/now` tool

## Testing
- `make lint`
- `make build`
- `make test`
- Started FastMCP server, `llamapool-server`, and `llamapool-mcp`
- `curl -s -X POST http://localhost:8080/mcp/time-client -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"time/now","arguments":{}}}'`

------
https://chatgpt.com/codex/tasks/task_e_68a23e3dd640832c8139fb634d1d8625