### PR TITLE
refactor mcp routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ It sits in front of existing LLM runtimes such as [Ollama](https://github.com/ol
 
 In addition to LLM workers, llamapool now supports relaying [Model Context Protocol](https://github.com/modelcontextprotocol) calls. 
 
-The server exposes a Streamable HTTP MCP endpoint at `POST /mcp` and forwards requests verbatim over WebSocket to a connected `llamapool-mcp` process. The legacy broker endpoint `POST /mcp/{client_id}` remains available. The broker enforces request/response size limits, per-client concurrency caps, and 30s call timeouts; cancellation is not yet implemented. The client negotiates protocol versions and server capabilities, and exposes tunables such as `MCP_PROTOCOL_VERSION`, `MCP_HTTP_TIMEOUT`, and `MCP_MAX_INFLIGHT` for advanced deployments.
+The server exposes a Streamable HTTP MCP endpoint at `POST /api/mcp/id/{id}` and forwards requests verbatim over WebSocket to a connected `llamapool-mcp` process. The broker enforces request/response size limits, per-client concurrency caps, and 30s call timeouts; cancellation is not yet implemented. The client negotiates protocol versions and server capabilities, and exposes tunables such as `MCP_PROTOCOL_VERSION`, `MCP_HTTP_TIMEOUT`, and `MCP_MAX_INFLIGHT` for advanced deployments.
 
 Server-initiated JSON-RPC requests (for example sampling calls) are forwarded across the WebSocket bridge and relayed back to clients, preserving full protocol semantics.
 
-The new `llamapool-mcp` binary connects a private MCP provider to the public `llamapool-server`, allowing clients to invoke MCP methods via `POST /mcp/{client_id}`. The broker enforces request/response size limits, per-client concurrency caps, and 30s call timeouts; cancellation is not yet implemented. The client negotiates protocol versions and server capabilities, and exposes tunables such as `MCP_PROTOCOL_VERSION`, `MCP_HTTP_TIMEOUT`, and `MCP_MAX_INFLIGHT` for advanced deployments. By default `llamapool-mcp` requires absolute stdio commands and verifies TLS certificates; set `MCP_STDIO_ALLOW_RELATIVE=true` or `MCP_HTTP_INSECURE_SKIP_VERIFY=true` to relax these checks, and `MCP_OAUTH_TOKEN_FILE` to securely cache OAuth tokens on disk.
+The new `llamapool-mcp` binary connects a private MCP provider to the public `llamapool-server`, allowing clients to invoke MCP methods via `POST /api/mcp/id/{id}`. The broker enforces request/response size limits, per-client concurrency caps, and 30s call timeouts; cancellation is not yet implemented. The client negotiates protocol versions and server capabilities, and exposes tunables such as `MCP_PROTOCOL_VERSION`, `MCP_HTTP_TIMEOUT`, and `MCP_MAX_INFLIGHT` for advanced deployments. By default `llamapool-mcp` requires absolute stdio commands and verifies TLS certificates; set `MCP_STDIO_ALLOW_RELATIVE=true` or `MCP_HTTP_INSECURE_SKIP_VERIFY=true` to relax these checks, and `MCP_OAUTH_TOKEN_FILE` to securely cache OAuth tokens on disk.
 By default the MCP relay exits if the server is unavailable. Add `-r` or `--reconnect` to keep retrying with backoff (1s×3, 5s×3, 15s×3, then every 30s). When enabled, it also probes the MCP provider and remains in a `not_ready` state until the provider becomes reachable.
 
 `llamapool-mcp` reads configuration from a YAML file when `MCP_CONFIG_FILE` is set. Values in the file—such as transport order, protocol version preference, or stdio working directory—are used as defaults and can be overridden by environment variables or CLI flags (e.g. `--mcp-http-url`, `--mcp-stdio-workdir`).
@@ -237,6 +237,7 @@ PORT=8080 WORKER_KEY=secret API_KEY=test123 go run ./cmd/llamapool-server
 ```
 
 Workers register with the server at `/api/workers/connect`.
+`llamapool-mcp` connects to the server at `ws://<server>/api/mcp/connect` and receives a unique id which is used by clients when calling `POST /api/mcp/id/{id}`.
 
 On Windows (CMD)
 

--- a/internal/mcp/broker_test.go
+++ b/internal/mcp/broker_test.go
@@ -13,11 +13,10 @@ import (
 
 func TestHTTPHandlerRelayOffline(t *testing.T) {
 	reg := NewRegistry()
-	reg.allowed = map[string]bool{"client": true}
 	rr := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/mcp/client", bytes.NewReader([]byte(`{"jsonrpc":"2.0","id":1,"method":"initialize"}`)))
+	req := httptest.NewRequest(http.MethodPost, "/api/mcp/id/client", bytes.NewReader([]byte(`{"jsonrpc":"2.0","id":1,"method":"initialize"}`)))
 	rctx := chi.NewRouteContext()
-	rctx.URLParams.Add("client_id", "client")
+	rctx.URLParams.Add("id", "client")
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 	reg.HTTPHandler()(rr, req)
 	if rr.Code != http.StatusServiceUnavailable {
@@ -40,13 +39,12 @@ func TestHTTPHandlerRelayOffline(t *testing.T) {
 
 func TestHTTPHandlerConcurrencyLimit(t *testing.T) {
 	reg := NewRegistry()
-	reg.allowed = map[string]bool{"client": true}
 	reg.maxConc = 1
 	reg.relays["client"] = &Relay{pending: map[string]chan Frame{}, inflight: 1, methods: map[string]int{}, sessions: map[string]sessionInfo{}}
 	rr := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/mcp/client", bytes.NewReader([]byte(`{"jsonrpc":"2.0","id":1,"method":"initialize"}`)))
+	req := httptest.NewRequest(http.MethodPost, "/api/mcp/id/client", bytes.NewReader([]byte(`{"jsonrpc":"2.0","id":1,"method":"initialize"}`)))
 	rctx := chi.NewRouteContext()
-	rctx.URLParams.Add("client_id", "client")
+	rctx.URLParams.Add("id", "client")
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 	reg.HTTPHandler()(rr, req)
 	if rr.Code != http.StatusTooManyRequests {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -57,8 +57,8 @@ func New(reg *ctrl.Registry, metrics *ctrl.MetricsRegistry, sched ctrl.Scheduler
 		apiGroup.Get("/state/stream", wrapper.GetApiStateStream)
 	})
 	if mcpReg != nil {
-		r.Post("/mcp/{client_id}", mcpReg.HTTPHandler())
-		r.Handle("/ws/relay", mcpReg.WSHandler())
+		r.Post("/api/mcp/id/{id}", mcpReg.HTTPHandler())
+		r.Handle("/api/mcp/connect", mcpReg.WSHandler())
 	}
 	r.Mount("/mcp", mcpserver.NewHandler())
 	r.Handle("/api/workers/connect", ctrl.WSHandler(reg, metrics, cfg.WorkerKey))


### PR DESCRIPTION
## Summary
- assign unique IDs to MCP clients on WebSocket connect
- expose MCP relay via `/api/mcp/connect` and route calls through `/api/mcp/id/{id}`
- update MCP client to request ID and log assigned identifier

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a532d6d9b4832cb41b4d51a45eea78