### PR TITLE
Remove legacy /v1 endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The Windows service runs `llamapool-worker` with the `--reconnect` flag and shut
   - Separate authentication keys for clients (`API_KEY`) and workers (`WORKER_KEY`).
   - Workers typically run behind firewalls and connect outbound over HTTPS/WSS.  
   - All traffic is encrypted end-to-end.
-- **Protocol compatibility** – Canonical endpoints are `/api/v1/*`, but the server also accepts OpenAI-style `POST /v1/chat/completions` and `POST /v1/embeddings` without altering JSON payloads.
+- **Protocol compatibility** – OpenAI-compatible endpoints are available under `/api/v1/*` without altering JSON payloads.
 
 ### How it works
 - The **server** accepts incoming HTTP requests from clients, authenticates them, and routes them to workers via WebSocket connections.
@@ -125,10 +125,10 @@ The Windows service runs `llamapool-worker` with the `--reconnect` flag and shut
 
 - Health: `GET /healthz`
 - OpenAI Models:
-  - `GET /api/v1/models` (also `/v1/models`)
-  - `GET /api/v1/models/{id}` (also `/v1/models/{id}`)
-- OpenAI Chat Completions: `POST /api/v1/chat/completions` (also `/v1/chat/completions`)
-- OpenAI Embeddings: `POST /api/v1/embeddings` (also `/v1/embeddings`)
+  - `GET /api/v1/models`
+  - `GET /api/v1/models/{id}`
+- OpenAI Chat Completions: `POST /api/v1/chat/completions`
+- OpenAI Embeddings: `POST /api/v1/embeddings`
 - llamapool API:
   - **State (JSON):** `GET /api/state`
   - **State (SSE):** `GET /api/state/stream`
@@ -142,7 +142,7 @@ The Windows service runs `llamapool-worker` with the `--reconnect` flag and shut
 
 ## Security
 
-- **Client authentication**: `API_KEY` required for `/api` routes (including `/api/v1`) and legacy `/v1` paths via `Authorization: Bearer <API_KEY>`.
+- **Client authentication**: `API_KEY` required for `/api` routes (including `/api/v1`) via `Authorization: Bearer <API_KEY>`.
 - **Worker authentication**: `WORKER_KEY` required for worker WebSocket registration.
 - **Transport**: run behind TLS (HTTPS/WSS) via reverse proxy or terminate TLS in-process.
 - **CORS**: cross-origin requests are denied unless explicitly allowed via `ALLOWED_ORIGINS` (comma separated) or the `--allowed-origins` flag.
@@ -468,12 +468,12 @@ For manual end-to-end verification on a clean VM, see [desktop/windows/ACCEPTANC
 
 | Feature | Supported | Notes |
 | --- | --- | --- |
-| OpenAI-compatible `POST /api/v1/chat/completions` | ✅ | Proxied to workers without payload mutation (also `/v1/chat/completions`) |
-| OpenAI-compatible `POST /api/v1/embeddings` | ✅ | Proxied to workers without payload mutation (also `/v1/embeddings`) |
+| OpenAI-compatible `POST /api/v1/chat/completions` | ✅ | Proxied to workers without payload mutation |
+| OpenAI-compatible `POST /api/v1/embeddings` | ✅ | Proxied to workers without payload mutation |
 | Multiple worker registration | ✅ | Workers can join/leave dynamically; models registered on connect |
 | Model-based routing (least-busy) | ✅ | `LeastBusyScheduler` selects worker by current load |
 | Model alias fallback | ✅ | Falls back to base model when exact quantization not available |
-| API key authentication for clients | ✅ | `Authorization: Bearer <API_KEY>` for `/api` (including `/api/v1`) and `/v1` routes |
+| API key authentication for clients | ✅ | `Authorization: Bearer <API_KEY>` for `/api` (including `/api/v1`) |
 | Worker key authentication | ✅ | Workers authenticate over WebSocket using `WORKER_KEY` |
 | Dynamic model discovery | ✅ | Workers advertise supported models; server aggregates |
 | HTTPS/WSS transport | ✅ | Use TLS terminator or run behind reverse proxy; WS path configurable |

--- a/api/generated/server.gen.go
+++ b/api/generated/server.gen.go
@@ -20,24 +20,24 @@ type ServerInterface interface {
 	// Stream server state
 	// (GET /api/state/stream)
 	GetApiStateStream(w http.ResponseWriter, r *http.Request)
+	// Chat completions (proxy)
+	// (POST /api/v1/chat/completions)
+	PostApiV1ChatCompletions(w http.ResponseWriter, r *http.Request)
+	// Embeddings (proxy)
+	// (POST /api/v1/embeddings)
+	PostApiV1Embeddings(w http.ResponseWriter, r *http.Request)
+	// List models
+	// (GET /api/v1/models)
+	GetApiV1Models(w http.ResponseWriter, r *http.Request)
+	// Get model
+	// (GET /api/v1/models/{id})
+	GetApiV1ModelsId(w http.ResponseWriter, r *http.Request, id string)
 	// Worker connect (WebSocket)
 	// (GET /api/workers/connect)
 	GetApiWorkersConnect(w http.ResponseWriter, r *http.Request)
 	// Health check
 	// (GET /healthz)
 	GetHealthz(w http.ResponseWriter, r *http.Request)
-	// Chat completions (proxy)
-	// (POST /v1/chat/completions)
-	PostV1ChatCompletions(w http.ResponseWriter, r *http.Request)
-	// Embeddings (proxy)
-	// (POST /v1/embeddings)
-	PostV1Embeddings(w http.ResponseWriter, r *http.Request)
-	// List models
-	// (GET /v1/models)
-	GetV1Models(w http.ResponseWriter, r *http.Request)
-	// Get model
-	// (GET /v1/models/{id})
-	GetV1ModelsId(w http.ResponseWriter, r *http.Request, id string)
 }
 
 // Unimplemented server implementation that returns http.StatusNotImplemented for each endpoint.
@@ -56,6 +56,30 @@ func (_ Unimplemented) GetApiStateStream(w http.ResponseWriter, r *http.Request)
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
+// Chat completions (proxy)
+// (POST /api/v1/chat/completions)
+func (_ Unimplemented) PostApiV1ChatCompletions(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Embeddings (proxy)
+// (POST /api/v1/embeddings)
+func (_ Unimplemented) PostApiV1Embeddings(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// List models
+// (GET /api/v1/models)
+func (_ Unimplemented) GetApiV1Models(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Get model
+// (GET /api/v1/models/{id})
+func (_ Unimplemented) GetApiV1ModelsId(w http.ResponseWriter, r *http.Request, id string) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
 // Worker connect (WebSocket)
 // (GET /api/workers/connect)
 func (_ Unimplemented) GetApiWorkersConnect(w http.ResponseWriter, r *http.Request) {
@@ -65,30 +89,6 @@ func (_ Unimplemented) GetApiWorkersConnect(w http.ResponseWriter, r *http.Reque
 // Health check
 // (GET /healthz)
 func (_ Unimplemented) GetHealthz(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(http.StatusNotImplemented)
-}
-
-// Chat completions (proxy)
-// (POST /v1/chat/completions)
-func (_ Unimplemented) PostV1ChatCompletions(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(http.StatusNotImplemented)
-}
-
-// Embeddings (proxy)
-// (POST /v1/embeddings)
-func (_ Unimplemented) PostV1Embeddings(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(http.StatusNotImplemented)
-}
-
-// List models
-// (GET /v1/models)
-func (_ Unimplemented) GetV1Models(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(http.StatusNotImplemented)
-}
-
-// Get model
-// (GET /v1/models/{id})
-func (_ Unimplemented) GetV1ModelsId(w http.ResponseWriter, r *http.Request, id string) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -141,36 +141,8 @@ func (siw *ServerInterfaceWrapper) GetApiStateStream(w http.ResponseWriter, r *h
 	handler.ServeHTTP(w, r)
 }
 
-// GetApiWorkersConnect operation middleware
-func (siw *ServerInterfaceWrapper) GetApiWorkersConnect(w http.ResponseWriter, r *http.Request) {
-
-	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetApiWorkersConnect(w, r)
-	}))
-
-	for _, middleware := range siw.HandlerMiddlewares {
-		handler = middleware(handler)
-	}
-
-	handler.ServeHTTP(w, r)
-}
-
-// GetHealthz operation middleware
-func (siw *ServerInterfaceWrapper) GetHealthz(w http.ResponseWriter, r *http.Request) {
-
-	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetHealthz(w, r)
-	}))
-
-	for _, middleware := range siw.HandlerMiddlewares {
-		handler = middleware(handler)
-	}
-
-	handler.ServeHTTP(w, r)
-}
-
-// PostV1ChatCompletions operation middleware
-func (siw *ServerInterfaceWrapper) PostV1ChatCompletions(w http.ResponseWriter, r *http.Request) {
+// PostApiV1ChatCompletions operation middleware
+func (siw *ServerInterfaceWrapper) PostApiV1ChatCompletions(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 
@@ -179,7 +151,7 @@ func (siw *ServerInterfaceWrapper) PostV1ChatCompletions(w http.ResponseWriter, 
 	r = r.WithContext(ctx)
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.PostV1ChatCompletions(w, r)
+		siw.Handler.PostApiV1ChatCompletions(w, r)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -189,8 +161,8 @@ func (siw *ServerInterfaceWrapper) PostV1ChatCompletions(w http.ResponseWriter, 
 	handler.ServeHTTP(w, r)
 }
 
-// PostV1Embeddings operation middleware
-func (siw *ServerInterfaceWrapper) PostV1Embeddings(w http.ResponseWriter, r *http.Request) {
+// PostApiV1Embeddings operation middleware
+func (siw *ServerInterfaceWrapper) PostApiV1Embeddings(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 
@@ -199,7 +171,7 @@ func (siw *ServerInterfaceWrapper) PostV1Embeddings(w http.ResponseWriter, r *ht
 	r = r.WithContext(ctx)
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.PostV1Embeddings(w, r)
+		siw.Handler.PostApiV1Embeddings(w, r)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -209,8 +181,8 @@ func (siw *ServerInterfaceWrapper) PostV1Embeddings(w http.ResponseWriter, r *ht
 	handler.ServeHTTP(w, r)
 }
 
-// GetV1Models operation middleware
-func (siw *ServerInterfaceWrapper) GetV1Models(w http.ResponseWriter, r *http.Request) {
+// GetApiV1Models operation middleware
+func (siw *ServerInterfaceWrapper) GetApiV1Models(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 
@@ -219,7 +191,7 @@ func (siw *ServerInterfaceWrapper) GetV1Models(w http.ResponseWriter, r *http.Re
 	r = r.WithContext(ctx)
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetV1Models(w, r)
+		siw.Handler.GetApiV1Models(w, r)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -229,8 +201,8 @@ func (siw *ServerInterfaceWrapper) GetV1Models(w http.ResponseWriter, r *http.Re
 	handler.ServeHTTP(w, r)
 }
 
-// GetV1ModelsId operation middleware
-func (siw *ServerInterfaceWrapper) GetV1ModelsId(w http.ResponseWriter, r *http.Request) {
+// GetApiV1ModelsId operation middleware
+func (siw *ServerInterfaceWrapper) GetApiV1ModelsId(w http.ResponseWriter, r *http.Request) {
 
 	var err error
 
@@ -250,7 +222,35 @@ func (siw *ServerInterfaceWrapper) GetV1ModelsId(w http.ResponseWriter, r *http.
 	r = r.WithContext(ctx)
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetV1ModelsId(w, r, id)
+		siw.Handler.GetApiV1ModelsId(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetApiWorkersConnect operation middleware
+func (siw *ServerInterfaceWrapper) GetApiWorkersConnect(w http.ResponseWriter, r *http.Request) {
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetApiWorkersConnect(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetHealthz operation middleware
+func (siw *ServerInterfaceWrapper) GetHealthz(w http.ResponseWriter, r *http.Request) {
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetHealthz(w, r)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -380,22 +380,22 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Get(options.BaseURL+"/api/state/stream", wrapper.GetApiStateStream)
 	})
 	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/api/v1/chat/completions", wrapper.PostApiV1ChatCompletions)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/api/v1/embeddings", wrapper.PostApiV1Embeddings)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/api/v1/models", wrapper.GetApiV1Models)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/api/v1/models/{id}", wrapper.GetApiV1ModelsId)
+	})
+	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/api/workers/connect", wrapper.GetApiWorkersConnect)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/healthz", wrapper.GetHealthz)
-	})
-	r.Group(func(r chi.Router) {
-		r.Post(options.BaseURL+"/v1/chat/completions", wrapper.PostV1ChatCompletions)
-	})
-	r.Group(func(r chi.Router) {
-		r.Post(options.BaseURL+"/v1/embeddings", wrapper.PostV1Embeddings)
-	})
-	r.Group(func(r chi.Router) {
-		r.Get(options.BaseURL+"/v1/models", wrapper.GetV1Models)
-	})
-	r.Group(func(r chi.Router) {
-		r.Get(options.BaseURL+"/v1/models/{id}", wrapper.GetV1ModelsId)
 	})
 
 	return r

--- a/api/generated/spec.gen.go
+++ b/api/generated/spec.gen.go
@@ -18,18 +18,18 @@ import (
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+RWX2vbOhT/KuY8teAbO7eXS/FbW8q9ZRsLBNqHEoYincZqbUmTTtJmwd99SHLitMnS",
-	"jLSDsSdh6ejo90c6PgvgujZaoSIHxQIc8qmVNB/yEmsMU+fILNqzKZUhICxAAeMwDSnQ3PjvkshA0zQp",
-	"SHWnfShJqvxKVbGaGa2r5GxwBSnM0DqpFRTQ7+W9HJoUtEHFjIQCTnp57wRSMIzKcHzGjMwcMUL/NUHy",
-	"gzZoGUmtrgQU8B/SmZHDEJOCRWe0chH833nuB64VoQpbmTGV5GFzdu88jJYUC6tCSL/EqoH1h5D0echO",
-	"cUVUj++RU6Qq0HErDUU6EYGfX8oIxe1zAW9HzSgFN61rZucReuLQztAmbrW7o5w5ssjqfZgPY+Sr/Amf",
-	"KMMZKvqrS94J0JJ0ZKWabCN56bcm7daf4hoR/oDuo7YPaF3GtVJe3t2Mb2L0RRv8gnQ/7/vhhTmPkngp",
-	"1SQZWE2a68pF+Ct8MWnSIkiObnA81PwB6TjCLJFVVH7bBe3/NuTAW2jW7t4CvFJTt80cf8zXqbQooLhd",
-	"xo32uKmfP7zgHoEnvET+ENnO+hkvGWW+PlTo9wUIRrst1Afa0XX/omR0sRYe4aGjcy3m7/kMOxV8SPML",
-	"a0B68HtaWrHvK/IiJ2umJEfG6qf58co1rMcohFSTV/267CL/AKsOVr6Ta0PzWgus3K7KcN3/FGPetDQI",
-	"RmFWEtZuc5lbZOS1XsCdtjUjKEAq+vef7rctFeEErf8JS7HlwqZLAbcuPSoUX8bz12uTFLDKlK5wrWXY",
-	"rFqrCWYtm29kDNRH72DzR+koaQ197m+2kKLZx+QrEToYy2oktC4cKT0W39VACoqFFiqI8vxBpDtKx+hN",
-	"r85vfTcOd9k3XsHVmCw2JdGpqa3afrbIskpzVpXaUXGan+bQjJrvAQAA//8HWlRXMwsAAA==",
+	"H4sIAAAAAAAC/+RW32vbOhT+V8x56gXf2Lm9jOK3tpStbGOBQPtQwlCk01itLWnSSVov+H8fktw4WbL+",
+	"IO1g7MlY54e+73xHOloC17XRChU5KJbgkM+tpGbMS6wxLJ0gs2iP51QGh2CAAqZhGVKgxvj/kshA27Yp",
+	"SHWtvStJqrylqljNjNZVcjw6hxQWaJ3UCgoYDvJBDm0K2qBiRkIBh4N8cAgpGEZl2D5jRmaOGKH/myH5",
+	"jzZoGUmtzgUU8B7p2Mhx8EnBojNauQj+vzz3H64VoQqhzJhK8hCc3TgPoyPFglUI6U2sGlm/CUmfh+wc",
+	"V0T19AY5RaoCHbfSUKQTEfj1hzJCcbVZwKtJO0nBzeua2SZCTxzaBdrEraJ7ypkji6x+DvNx9HySP+E9",
+	"ZbhARf/2yfsCdCQdWalmu0ie+dCkC30R14jwF3QXw4yXjDLfjhX6vQJ+o90O2iPtPO+L4WnJ6HQtwrP/",
+	"NkdHJ1o0bym830ZaFNGl/Y1dl+6t4JePL9PNFzlZ0yU5MFbfN/9siIf1FIWQavYc2c56579Asb0F6Mu1",
+	"s/S1Fli5J+6Ii+Hn6LYncbNGdwmCUViVhLXbNnOLjHzJl3Ctbc0ICpCK3v3fjw2pCGdo/RCQYkf7pg91",
+	"3Gm6Uyi+Tptdbb+u+JXPvcqUrnCtZZhs6bZaYNayZitjoD55A7U/SUdJp+m2zNlSivaZWp+LMEgtq5HQ",
+	"urCz9JD8cIUUFAuTPNRm83ikj9wnk1ftoD+6RfYX28//IGwv9Z22t2hdxrVSHatHtL6M3qed80/aDPNh",
+	"OKabz5Q7SbyUapaMrCbNdddoPaqYNOkQJAeXOB1rfovUXTwlsorK749B+9C5vGqz+DfD3D0tZef3EsFW",
+	"3CPwhJfIb2NAfLDE4zO3VffWLbKs0pxVpXZUHOVHObST9kcAAAD//7Ja/w5PCwAA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/api/generated/types.gen.go
+++ b/api/generated/types.gen.go
@@ -7,14 +7,14 @@ const (
 	BearerAuthScopes = "BearerAuth.Scopes"
 )
 
-// PostV1ChatCompletionsJSONBody defines parameters for PostV1ChatCompletions.
-type PostV1ChatCompletionsJSONBody map[string]interface{}
+// PostApiV1ChatCompletionsJSONBody defines parameters for PostApiV1ChatCompletions.
+type PostApiV1ChatCompletionsJSONBody map[string]interface{}
 
-// PostV1EmbeddingsJSONBody defines parameters for PostV1Embeddings.
-type PostV1EmbeddingsJSONBody map[string]interface{}
+// PostApiV1EmbeddingsJSONBody defines parameters for PostApiV1Embeddings.
+type PostApiV1EmbeddingsJSONBody map[string]interface{}
 
-// PostV1ChatCompletionsJSONRequestBody defines body for PostV1ChatCompletions for application/json ContentType.
-type PostV1ChatCompletionsJSONRequestBody PostV1ChatCompletionsJSONBody
+// PostApiV1ChatCompletionsJSONRequestBody defines body for PostApiV1ChatCompletions for application/json ContentType.
+type PostApiV1ChatCompletionsJSONRequestBody PostApiV1ChatCompletionsJSONBody
 
-// PostV1EmbeddingsJSONRequestBody defines body for PostV1Embeddings for application/json ContentType.
-type PostV1EmbeddingsJSONRequestBody PostV1EmbeddingsJSONBody
+// PostApiV1EmbeddingsJSONRequestBody defines body for PostApiV1Embeddings for application/json ContentType.
+type PostApiV1EmbeddingsJSONRequestBody PostApiV1EmbeddingsJSONBody

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -30,7 +30,7 @@ paths:
       responses:
         '101':
           description: Switching Protocols
-  /v1/models:
+  /api/v1/models:
     get:
       security: [ { BearerAuth: [] } ]
       summary: List models
@@ -58,7 +58,7 @@ paths:
                           type: string
                       required: [id, object, created, owned_by]
                 required: [data]
-  /v1/models/{id}:
+  /api/v1/models/{id}:
     get:
       security: [ { BearerAuth: [] } ]
       summary: Get model
@@ -86,7 +86,7 @@ paths:
                   owned_by:
                     type: string
                 required: [id, object, created, owned_by]
-  /v1/chat/completions:
+  /api/v1/chat/completions:
     post:
       security: [ { BearerAuth: [] } ]
       summary: Chat completions (proxy)
@@ -108,7 +108,7 @@ paths:
             text/event-stream:
               schema:
                 type: string
-  /v1/embeddings:
+  /api/v1/embeddings:
     post:
       security: [ { BearerAuth: [] } ]
       summary: Embeddings (proxy)

--- a/docs/server-endpoints.md
+++ b/docs/server-endpoints.md
@@ -21,7 +21,7 @@ Endpoints are grouped by functional area.
 
 ## Inference API
 
-### `/api/v1` (preferred)
+### `/api/v1`
 
 | Verb & Endpoint | Parameters | Description | Auth |
 | --- | --- | --- | --- |
@@ -29,15 +29,6 @@ Endpoints are grouped by functional area.
 | `POST /api/v1/embeddings` | Body `{ model: string, input: any, ... }` | Proxy OpenAI embeddings. | API key |
 | `GET /api/v1/models` | – | List models. | API key |
 | `GET /api/v1/models/{id}` | Path `{id}` | Get model details. | API key |
-
-### `/v1` (legacy)
-
-| Verb & Endpoint | Parameters | Description | Auth |
-| --- | --- | --- | --- |
-| `POST /v1/chat/completions` | Body `{ model: string, messages: [{role: string, content: string}], stream?: bool, ... }` | Legacy path for chat completions. | API key |
-| `POST /v1/embeddings` | Body `{ model: string, input: any, ... }` | Legacy path for embeddings. | API key |
-| `GET /v1/models` | – | Legacy path for list models. | API key |
-| `GET /v1/models/{id}` | Path `{id}` | Legacy path for model details. | API key |
 
 ### Workers
 
@@ -62,9 +53,5 @@ Endpoints are grouped by functional area.
 
 | Endpoint | Reason |
 | --- | --- |
-| `POST /v1/chat/completions` | Superseded by `/api/v1/chat/completions`. |
-| `POST /v1/embeddings` | Superseded by `/api/v1/embeddings`. |
-| `GET /v1/models` | Superseded by `/api/v1/models`. |
-| `GET /v1/models/{id}` | Superseded by `/api/v1/models/{id}`. |
 | `POST /mcp` | Early MCP streaming endpoint, replaced by `/api/mcp/id/{id}`. |
 | `GET /mcp` | Early MCP event stream (SSE), replaced by `/api/mcp/connect`. |

--- a/examples/llm-proxy/docker-compose.yaml
+++ b/examples/llm-proxy/docker-compose.yaml
@@ -1,5 +1,5 @@
 x-env: &common_env
-  API_KEY: "test123"     # client API key for /v1 and /api
+  API_KEY: "test123"     # client API key for /api
   WORKER_KEY: "secret"   # worker registration key
 
 services:

--- a/examples/llm-proxy/example.md
+++ b/examples/llm-proxy/example.md
@@ -1,6 +1,6 @@
 ```
 x-env: &common_env
-  API_KEY: "test123"     # client API key for /v1 and /api
+  API_KEY: "test123"     # client API key for /api
   WORKER_KEY: "secret"   # worker registration key
 
 services:
@@ -49,6 +49,6 @@ docker exec ollama ollama pull gemma3n:e2b
 ```
 
 ```
-docker run --rm -e OPENAI_API_KEY=test123 -e OPENAI_API_BASE=http://host.docker.internal:8080/v1/ ghcr.io/tbckr/sgpt:latest -m gemma3n:e2b "Tell me an IT joke about http proxies"
+docker run --rm -e OPENAI_API_KEY=test123 -e OPENAI_API_BASE=http://host.docker.internal:8080/api/v1/ ghcr.io/tbckr/sgpt:latest -m gemma3n:e2b "Tell me an IT joke about http proxies"
 ```
 

--- a/examples/mcp-proxy/docker-compose.yaml
+++ b/examples/mcp-proxy/docker-compose.yaml
@@ -1,5 +1,5 @@
 x-env: &common_env
-  API_KEY: "test123"     # client API key for /v1 and /api
+  API_KEY: "test123"     # client API key for /api
   WORKER_KEY: "secret"   # worker registration key
   CLIENT_ID: mcp-1234    # a unique identifier for this mcp server
 

--- a/examples/mcp-proxy/example.md
+++ b/examples/mcp-proxy/example.md
@@ -9,7 +9,7 @@ Define the following `docker-compose.yaml`:
 
 ```
 x-env: &common_env
-  API_KEY: "test123"     # client API key for /v1 and /api
+  API_KEY: "test123"     # client API key for /api
   WORKER_KEY: "secret"   # worker registration key
   CLIENT_ID: mcp-1234    # a unique identifier for this mcp server
   

--- a/internal/api/chat_completions.go
+++ b/internal/api/chat_completions.go
@@ -15,7 +15,7 @@ import (
 	"github.com/gaspardpetit/llamapool/internal/metrics"
 )
 
-// ChatCompletionsHandler handles POST /v1/chat/completions as a pass-through.
+// ChatCompletionsHandler handles POST /api/v1/chat/completions as a pass-through.
 func ChatCompletionsHandler(reg *ctrl.Registry, sched ctrl.Scheduler, metricsReg *ctrl.MetricsRegistry) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Body == nil {

--- a/internal/api/chat_completions_test.go
+++ b/internal/api/chat_completions_test.go
@@ -35,7 +35,7 @@ func TestChatCompletionsHeaders(t *testing.T) {
 	}()
 
 	reqBody := `{"model":"m","stream":true}`
-	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(reqBody))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/chat/completions", strings.NewReader(reqBody))
 	req.Header.Set("Content-Type", "application/json")
 	rec := &flushRecorder{ResponseRecorder: httptest.NewRecorder()}
 	h.ServeHTTP(rec, req)
@@ -71,7 +71,7 @@ func TestChatCompletionsOpaque(t *testing.T) {
 		ch <- ctrl.HTTPProxyResponseEndMessage{Type: "http_proxy_response_end", RequestID: req.RequestID}
 	}()
 
-	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"m"}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/chat/completions", strings.NewReader(`{"model":"m"}`))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
@@ -96,7 +96,7 @@ func TestChatCompletionsEarlyError(t *testing.T) {
 		ch <- ctrl.HTTPProxyResponseEndMessage{Type: "http_proxy_response_end", RequestID: req.RequestID, Error: &ctrl.HTTPProxyError{Code: "upstream_error", Message: "boom"}}
 	}()
 
-	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader([]byte(`{"model":"m"}`)))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/chat/completions", bytes.NewReader([]byte(`{"model":"m"}`)))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)

--- a/internal/api/embeddings.go
+++ b/internal/api/embeddings.go
@@ -15,7 +15,7 @@ import (
 	"github.com/gaspardpetit/llamapool/internal/metrics"
 )
 
-// EmbeddingsHandler handles POST /v1/embeddings as a pass-through.
+// EmbeddingsHandler handles POST /api/v1/embeddings as a pass-through.
 func EmbeddingsHandler(reg *ctrl.Registry, sched ctrl.Scheduler, metricsReg *ctrl.MetricsRegistry) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Body == nil {

--- a/internal/api/embeddings_test.go
+++ b/internal/api/embeddings_test.go
@@ -27,7 +27,7 @@ func TestEmbeddings(t *testing.T) {
 		ch <- ctrl.HTTPProxyResponseEndMessage{Type: "http_proxy_response_end", RequestID: req.RequestID}
 	}()
 
-	req := httptest.NewRequest(http.MethodPost, "/v1/embeddings", strings.NewReader(`{"model":"m"}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/embeddings", strings.NewReader(`{"model":"m"}`))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
@@ -55,7 +55,7 @@ func TestEmbeddingsEarlyError(t *testing.T) {
 		ch <- ctrl.HTTPProxyResponseEndMessage{Type: "http_proxy_response_end", RequestID: req.RequestID, Error: &ctrl.HTTPProxyError{Code: "upstream_error", Message: "boom"}}
 	}()
 
-	req := httptest.NewRequest(http.MethodPost, "/v1/embeddings", bytes.NewReader([]byte(`{"model":"m"}`)))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/embeddings", bytes.NewReader([]byte(`{"model":"m"}`)))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)

--- a/internal/api/impl.go
+++ b/internal/api/impl.go
@@ -37,19 +37,19 @@ func (a *API) GetHealthz(w http.ResponseWriter, r *http.Request) {
 	_, _ = fmt.Fprintf(w, `{"status":"%s"}`, status)
 }
 
-func (a *API) PostV1ChatCompletions(w http.ResponseWriter, r *http.Request) {
+func (a *API) PostApiV1ChatCompletions(w http.ResponseWriter, r *http.Request) {
 	ChatCompletionsHandler(a.Reg, a.Sched, a.Metrics)(w, r)
 }
 
-func (a *API) PostV1Embeddings(w http.ResponseWriter, r *http.Request) {
+func (a *API) PostApiV1Embeddings(w http.ResponseWriter, r *http.Request) {
 	EmbeddingsHandler(a.Reg, a.Sched, a.Metrics)(w, r)
 }
 
-func (a *API) GetV1Models(w http.ResponseWriter, r *http.Request) {
+func (a *API) GetApiV1Models(w http.ResponseWriter, r *http.Request) {
 	ListModelsHandler(a.Reg)(w, r)
 }
 
-func (a *API) GetV1ModelsId(w http.ResponseWriter, r *http.Request, id string) {
+func (a *API) GetApiV1ModelsId(w http.ResponseWriter, r *http.Request, id string) {
 	GetModelHandler(a.Reg)(w, r)
 }
 

--- a/internal/api/models.go
+++ b/internal/api/models.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gaspardpetit/llamapool/internal/logx"
 )
 
-// ListModelsHandler handles GET /v1/models.
+// ListModelsHandler handles GET /api/v1/models.
 func ListModelsHandler(reg *ctrl.Registry) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		models := reg.AggregatedModels()
@@ -36,7 +36,7 @@ func ListModelsHandler(reg *ctrl.Registry) http.HandlerFunc {
 	}
 }
 
-// GetModelHandler handles GET /v1/models/{id}.
+// GetModelHandler handles GET /api/v1/models/{id}.
 func GetModelHandler(reg *ctrl.Registry) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "id")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -48,10 +48,10 @@ func New(reg *ctrl.Registry, metrics *ctrl.MetricsRegistry, sched ctrl.Scheduler
 			apiGroup.Use(api.APIKeyMiddleware(cfg.APIKey))
 		}
 		apiGroup.Route("/v1", func(v1 chi.Router) {
-			v1.Post("/chat/completions", wrapper.PostV1ChatCompletions)
-			v1.Post("/embeddings", wrapper.PostV1Embeddings)
-			v1.Get("/models", wrapper.GetV1Models)
-			v1.Get("/models/{id}", wrapper.GetV1ModelsId)
+			v1.Post("/chat/completions", wrapper.PostApiV1ChatCompletions)
+			v1.Post("/embeddings", wrapper.PostApiV1Embeddings)
+			v1.Get("/models", wrapper.GetApiV1Models)
+			v1.Get("/models/{id}", wrapper.GetApiV1ModelsId)
 		})
 		apiGroup.Get("/state", wrapper.GetApiState)
 		apiGroup.Get("/state/stream", wrapper.GetApiStateStream)
@@ -63,15 +63,6 @@ func New(reg *ctrl.Registry, metrics *ctrl.MetricsRegistry, sched ctrl.Scheduler
 	r.Mount("/mcp", mcpserver.NewHandler())
 	r.Handle("/api/workers/connect", ctrl.WSHandler(reg, metrics, cfg.WorkerKey))
 
-	r.Group(func(openai chi.Router) {
-		if cfg.APIKey != "" {
-			openai.Use(api.APIKeyMiddleware(cfg.APIKey))
-		}
-		openai.Post("/v1/chat/completions", wrapper.PostV1ChatCompletions)
-		openai.Post("/v1/embeddings", wrapper.PostV1Embeddings)
-		openai.Get("/v1/models", wrapper.GetV1Models)
-		openai.Get("/v1/models/{id}", wrapper.GetV1ModelsId)
-	})
 	metricsPort := cfg.MetricsPort
 	if metricsPort == 0 {
 		metricsPort = cfg.Port

--- a/test/e2e_api_key_test.go
+++ b/test/e2e_api_key_test.go
@@ -21,7 +21,7 @@ func TestAPIKeyEnforcement(t *testing.T) {
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
-	resp, err := http.Get(srv.URL + "/v1/models")
+	resp, err := http.Get(srv.URL + "/api/v1/models")
 	if err != nil {
 		t.Fatalf("get without key: %v", err)
 	}
@@ -32,7 +32,7 @@ func TestAPIKeyEnforcement(t *testing.T) {
 		t.Fatalf("close body: %v", err)
 	}
 
-	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/v1/models", nil)
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/api/v1/models", nil)
 	req.Header.Set("Authorization", "Bearer test123")
 	resp, err = http.DefaultClient.Do(req)
 	if err != nil {

--- a/test/e2e_auth_test.go
+++ b/test/e2e_auth_test.go
@@ -71,7 +71,7 @@ func TestWorkerAuth(t *testing.T) {
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/v1/models", nil)
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/api/v1/models", nil)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil || resp.StatusCode != http.StatusOK {
 		t.Fatalf("models: %v %d", err, resp.StatusCode)

--- a/test/e2e_chat_completions_proxy_test.go
+++ b/test/e2e_chat_completions_proxy_test.go
@@ -70,7 +70,7 @@ func TestE2EChatCompletionsProxy(t *testing.T) {
 
 	// wait for worker registration
 	for i := 0; i < 20; i++ {
-		resp, err := http.Get(srv.URL + "/v1/models")
+		resp, err := http.Get(srv.URL + "/api/v1/models")
 		if err == nil {
 			var v struct {
 				Data []struct {
@@ -89,7 +89,7 @@ func TestE2EChatCompletionsProxy(t *testing.T) {
 	}
 
 	reqBody := []byte(`{"model":"llama3","stream":true}`)
-	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/v1/chat/completions", bytes.NewReader(reqBody))
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/api/v1/chat/completions", bytes.NewReader(reqBody))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer apikey")
 	resp, err := http.DefaultClient.Do(req)

--- a/test/e2e_embeddings_proxy_test.go
+++ b/test/e2e_embeddings_proxy_test.go
@@ -56,7 +56,7 @@ func TestE2EEmbeddingsProxy(t *testing.T) {
 	}()
 
 	for i := 0; i < 20; i++ {
-		resp, err := http.Get(srv.URL + "/v1/models")
+		resp, err := http.Get(srv.URL + "/api/v1/models")
 		if err == nil {
 			var v struct {
 				Data []struct {
@@ -75,7 +75,7 @@ func TestE2EEmbeddingsProxy(t *testing.T) {
 	}
 
 	reqBody := []byte(`{"model":"llama3","input":"hi"}`)
-	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/v1/embeddings", bytes.NewReader(reqBody))
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/api/v1/embeddings", bytes.NewReader(reqBody))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer apikey")
 	resp, err := http.DefaultClient.Do(req)

--- a/test/e2e_model_update_test.go
+++ b/test/e2e_model_update_test.go
@@ -42,7 +42,7 @@ func TestWorkerModelRefresh(t *testing.T) {
 
 	waitForModels := func(n int, expect string) {
 		for i := 0; i < 50; i++ {
-			resp, err := http.Get(srv.URL + "/v1/models")
+			resp, err := http.Get(srv.URL + "/api/v1/models")
 			if err == nil {
 				var lr struct {
 					Data []struct {

--- a/test/e2e_models_api_test.go
+++ b/test/e2e_models_api_test.go
@@ -53,7 +53,7 @@ func TestModelsAPI(t *testing.T) {
 
 	// wait for registration
 	for i := 0; i < 50; i++ {
-		resp, err := http.Get(srv.URL + "/v1/models")
+		resp, err := http.Get(srv.URL + "/api/v1/models")
 		if err == nil {
 			var lr struct {
 				Data []struct {
@@ -72,7 +72,7 @@ func TestModelsAPI(t *testing.T) {
 		time.Sleep(20 * time.Millisecond)
 	}
 
-	resp, err := http.Get(srv.URL + "/v1/models")
+	resp, err := http.Get(srv.URL + "/api/v1/models")
 	if err != nil {
 		t.Fatalf("list models: %v", err)
 	}
@@ -96,12 +96,12 @@ func TestModelsAPI(t *testing.T) {
 		}
 	}
 
-	resp, err = http.Get(srv.URL + "/v1/models/llama3:8b")
+	resp, err = http.Get(srv.URL + "/api/v1/models/llama3:8b")
 	if err != nil || resp.StatusCode != http.StatusOK {
 		t.Fatalf("get model: %v %d", err, resp.StatusCode)
 	}
 	_ = resp.Body.Close()
-	resp, err = http.Get(srv.URL + "/v1/models/doesnotexist")
+	resp, err = http.Get(srv.URL + "/api/v1/models/doesnotexist")
 	if err != nil || resp.StatusCode != http.StatusNotFound {
 		t.Fatalf("missing model: %v %d", err, resp.StatusCode)
 	}
@@ -110,7 +110,7 @@ func TestModelsAPI(t *testing.T) {
 	_ = connB.Close(websocket.StatusNormalClosure, "")
 	// wait for deregistration
 	for i := 0; i < 50; i++ {
-		resp, err := http.Get(srv.URL + "/v1/models")
+		resp, err := http.Get(srv.URL + "/api/v1/models")
 		if err == nil {
 			var lr struct {
 				Data []struct {
@@ -129,7 +129,7 @@ func TestModelsAPI(t *testing.T) {
 		time.Sleep(20 * time.Millisecond)
 	}
 
-	resp, err = http.Get(srv.URL + "/v1/models")
+	resp, err = http.Get(srv.URL + "/api/v1/models")
 	if err != nil {
 		t.Fatalf("list after disconnect: %v", err)
 	}


### PR DESCRIPTION
## Summary
- drop support for root-level `/v1` API routes
- document and expose only `/api/v1` endpoints
- update tests and examples to new paths

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a6a2811ef4832cbed1a27e608b6be2