### PR TITLE
auth: rename worker key to client key

### DIFF
--- a/cmd/llamapool-mcp/main.go
+++ b/cmd/llamapool-mcp/main.go
@@ -100,6 +100,8 @@ func main() {
 	reconnectFlag := getEnvBool("RECONNECT", false)
 	flag.BoolVar(&reconnectFlag, "reconnect", reconnectFlag, "reconnect to server on failure")
 	flag.BoolVar(&reconnectFlag, "r", reconnectFlag, "short for --reconnect")
+	clientKey := getEnv("CLIENT_KEY", "")
+	flag.StringVar(&clientKey, "client-key", clientKey, "shared secret for authenticating with the server")
 	flag.Parse()
 	if *showVersion {
 		fmt.Printf("llamapool-mcp version=%s sha=%s date=%s\n", version, buildSHA, buildDate)
@@ -127,6 +129,9 @@ func main() {
 			continue
 		}
 		reg := map[string]string{"id": clientID}
+		if clientKey != "" {
+			reg["client_key"] = clientKey
+		}
 		b, _ := json.Marshal(reg)
 		if err := conn.Write(ctx, websocket.MessageText, b); err != nil {
 			_ = conn.Close(websocket.StatusInternalError, "closing")

--- a/cmd/llamapool-server/main.go
+++ b/cmd/llamapool-server/main.go
@@ -85,8 +85,8 @@ func main() {
 	if cfg.APIKey != "" {
 		logx.Log.Info().Msg("API key auth enabled")
 	}
-	if cfg.WorkerKey != "" {
-		logx.Log.Info().Msg("Worker key required")
+	if cfg.ClientKey != "" {
+		logx.Log.Info().Msg("Client key required")
 	}
 	logx.Log.Info().Int("port", cfg.Port).Msg("server starting")
 	if metricsSrv != nil {

--- a/cmd/llamapool-worker/main.go
+++ b/cmd/llamapool-worker/main.go
@@ -75,7 +75,7 @@ func main() {
 	}()
 
 	log := logx.Log.Info().Str("worker_name", cfg.WorkerName)
-	if cfg.WorkerKey != "" {
+	if cfg.ClientKey != "" {
 		log = log.Bool("auth", true)
 	}
 	log.Msg("worker starting")

--- a/debian/examples/server.env
+++ b/debian/examples/server.env
@@ -1,5 +1,5 @@
 # Example environment file for llamapool-server
 # Uncomment and set values as needed.
 # API_KEY=your_api_key
-# WORKER_KEY=your_worker_key
+# CLIENT_KEY=your_client_key
 # LISTEN_ADDR=:8080

--- a/debian/examples/worker.env
+++ b/debian/examples/worker.env
@@ -1,6 +1,6 @@
 # Example environment file for llamapool-worker
 # Uncomment and set values as needed.
 # SERVER_URL=ws://localhost:8080/api/workers/connect
-# WORKER_KEY=secret
+# CLIENT_KEY=secret
 # OLLAMA_BASE_URL=http://127.0.0.1:11434
 # WORKER_NAME=MyWorker

--- a/deploy/systemd/server.env.example
+++ b/deploy/systemd/server.env.example
@@ -1,5 +1,5 @@
 # Example environment file for llamapool-server
 # Uncomment and set values as needed.
 # API_KEY=your_api_key
-# WORKER_KEY=your_worker_key
+# CLIENT_KEY=your_client_key
 # LISTEN_ADDR=:8080

--- a/deploy/systemd/worker.env.example
+++ b/deploy/systemd/worker.env.example
@@ -1,6 +1,6 @@
 # Example environment file for llamapool-worker
 # Uncomment and set values as needed.
 # SERVER_URL=ws://localhost:8080/api/workers/connect
-# WORKER_KEY=secret
+# CLIENT_KEY=secret
 # OLLAMA_BASE_URL=http://127.0.0.1:11434
 # WORKER_NAME=MyWorker

--- a/desktop/macos/llamapool/llamapool/WorkerConfig.swift
+++ b/desktop/macos/llamapool/llamapool/WorkerConfig.swift
@@ -2,14 +2,14 @@ import Foundation
 
 struct WorkerConfig: Equatable {
     var serverURL: String
-    var workerKey: String
+    var clientKey: String
     var ollamaBaseURL: String
     var maxConcurrency: Int
     var statusPort: Int
 
-    init(serverURL: String = "", workerKey: String = "", ollamaBaseURL: String = "", maxConcurrency: Int = 1, statusPort: Int = 4555) {
+    init(serverURL: String = "", clientKey: String = "", ollamaBaseURL: String = "", maxConcurrency: Int = 1, statusPort: Int = 4555) {
         self.serverURL = serverURL
-        self.workerKey = workerKey
+        self.clientKey = clientKey
         self.ollamaBaseURL = ollamaBaseURL
         self.maxConcurrency = maxConcurrency
         self.statusPort = statusPort
@@ -18,7 +18,7 @@ struct WorkerConfig: Equatable {
     func toYAML() -> String {
         return """
 server_url: \(serverURL)
-worker_key: \(workerKey)
+client_key: \(clientKey)
 ollama_base_url: \(ollamaBaseURL)
 max_concurrency: \(maxConcurrency)
 status_port: \(statusPort)
@@ -34,11 +34,11 @@ status_port: \(statusPort)
             }
         }
         let serverURL = dict["server_url"] ?? ""
-        let workerKey = dict["worker_key"] ?? ""
+        let clientKey = dict["client_key"] ?? ""
         let ollamaBaseURL = dict["ollama_base_url"] ?? ""
         let maxConcurrency = Int(dict["max_concurrency"] ?? "1") ?? 1
         let statusPort = Int(dict["status_port"] ?? "4555") ?? 4555
-        return WorkerConfig(serverURL: serverURL, workerKey: workerKey, ollamaBaseURL: ollamaBaseURL, maxConcurrency: maxConcurrency, statusPort: statusPort)
+        return WorkerConfig(serverURL: serverURL, clientKey: clientKey, ollamaBaseURL: ollamaBaseURL, maxConcurrency: maxConcurrency, statusPort: statusPort)
     }
 
     func isValid() -> Bool {

--- a/desktop/windows/Installer/worker.yaml
+++ b/desktop/windows/Installer/worker.yaml
@@ -1,6 +1,6 @@
 debug: false
 server_url: ""
-worker_key: ""
+client_key: ""
 ollama_base_url: "http://127.0.0.1:11434"
 max_concurrency: 1
 status_addr: "127.0.0.1:4555"

--- a/desktop/windows/TrayApp.Tests/WorkerConfigTests.cs
+++ b/desktop/windows/TrayApp.Tests/WorkerConfigTests.cs
@@ -10,7 +10,7 @@ public class WorkerConfigTests
         var cfg = new WorkerConfig
         {
             ServerUrl = "wss://example",
-            WorkerKey = "secret",
+            ClientKey = "secret",
             OllamaBaseUrl = "http://ollama",
             MaxConcurrency = 3,
             StatusPort = 5000
@@ -21,7 +21,7 @@ public class WorkerConfigTests
             cfg.Save(path);
             var loaded = WorkerConfig.Load(path);
             Assert.Equal(cfg.ServerUrl, loaded.ServerUrl);
-            Assert.Equal(cfg.WorkerKey, loaded.WorkerKey);
+            Assert.Equal(cfg.ClientKey, loaded.ClientKey);
             Assert.Equal(cfg.OllamaBaseUrl, loaded.OllamaBaseUrl);
             Assert.Equal(cfg.MaxConcurrency, loaded.MaxConcurrency);
             Assert.Equal(cfg.StatusPort, loaded.StatusPort);

--- a/desktop/windows/TrayApp/PreferencesForm.cs
+++ b/desktop/windows/TrayApp/PreferencesForm.cs
@@ -6,7 +6,7 @@ namespace TrayApp;
 public class PreferencesForm : Form
 {
     private readonly TextBox _serverUrl;
-    private readonly TextBox _workerKey;
+    private readonly TextBox _clientKey;
     private readonly TextBox _ollamaUrl;
     private readonly NumericUpDown _maxConcurrency;
     private readonly NumericUpDown _statusPort;
@@ -23,7 +23,7 @@ public class PreferencesForm : Form
         Config = config;
 
         _serverUrl = new TextBox { Dock = DockStyle.Fill, Text = config.ServerUrl };
-        _workerKey = new TextBox { Dock = DockStyle.Fill, Text = config.WorkerKey };
+        _clientKey = new TextBox { Dock = DockStyle.Fill, Text = config.ClientKey };
         _ollamaUrl = new TextBox { Dock = DockStyle.Fill, Text = config.OllamaBaseUrl };
         _maxConcurrency = new NumericUpDown { Dock = DockStyle.Fill, Minimum = 1, Maximum = 128, Value = config.MaxConcurrency };
         _statusPort = new NumericUpDown { Dock = DockStyle.Fill, Minimum = 1, Maximum = 65535, Value = config.StatusPort };
@@ -34,8 +34,8 @@ public class PreferencesForm : Form
 
         table.Controls.Add(new Label { Text = "Server URL", Anchor = AnchorStyles.Left, AutoSize = true }, 0, 0);
         table.Controls.Add(_serverUrl, 1, 0);
-        table.Controls.Add(new Label { Text = "Worker Key", Anchor = AnchorStyles.Left, AutoSize = true }, 0, 1);
-        table.Controls.Add(_workerKey, 1, 1);
+        table.Controls.Add(new Label { Text = "Client Key", Anchor = AnchorStyles.Left, AutoSize = true }, 0, 1);
+        table.Controls.Add(_clientKey, 1, 1);
         table.Controls.Add(new Label { Text = "Ollama Base URL", Anchor = AnchorStyles.Left, AutoSize = true }, 0, 2);
         table.Controls.Add(_ollamaUrl, 1, 2);
         table.Controls.Add(new Label { Text = "Max Concurrency", Anchor = AnchorStyles.Left, AutoSize = true }, 0, 3);
@@ -60,7 +60,7 @@ public class PreferencesForm : Form
     private void UpdateConfig()
     {
         Config.ServerUrl = _serverUrl.Text.Trim();
-        Config.WorkerKey = _workerKey.Text.Trim();
+        Config.ClientKey = _clientKey.Text.Trim();
         Config.OllamaBaseUrl = _ollamaUrl.Text.Trim();
         Config.MaxConcurrency = (int)_maxConcurrency.Value;
         Config.StatusPort = (int)_statusPort.Value;

--- a/desktop/windows/TrayApp/TrayAppContext.cs
+++ b/desktop/windows/TrayApp/TrayAppContext.cs
@@ -157,7 +157,7 @@ public class TrayAppContext : ApplicationContext
         using var form = new PreferencesForm(new WorkerConfig
         {
             ServerUrl = _config.ServerUrl,
-            WorkerKey = _config.WorkerKey,
+            ClientKey = _config.ClientKey,
             OllamaBaseUrl = _config.OllamaBaseUrl,
             MaxConcurrency = _config.MaxConcurrency,
             StatusPort = _config.StatusPort

--- a/desktop/windows/TrayApp/WorkerConfig.cs
+++ b/desktop/windows/TrayApp/WorkerConfig.cs
@@ -7,7 +7,7 @@ namespace TrayApp;
 public class WorkerConfig
 {
     public string ServerUrl { get; set; } = "";
-    public string WorkerKey { get; set; } = "";
+    public string ClientKey { get; set; } = "";
     public string OllamaBaseUrl { get; set; } = "http://127.0.0.1:11434";
     public int MaxConcurrency { get; set; } = 2;
 

--- a/docs/env.md
+++ b/docs/env.md
@@ -17,7 +17,7 @@ llamapool-server does not currently read from a configuration file; settings are
 | `PORT` | — | HTTP listen port for the public API | `8080` | `--port` |
 | `METRICS_PORT` | — | Prometheus metrics listen port | same as `PORT` | `--metrics-port` |
 | `API_KEY` | — | client API key required for HTTP requests | unset (auth disabled) | `--api-key` |
-| `WORKER_KEY` | — | shared key workers must present when registering | unset | `--worker-key` |
+| `CLIENT_KEY` | — | shared key clients must present when registering | unset | `--client-key` |
 | `REQUEST_TIMEOUT` | — | maximum duration to process a client request | `60s` | `--request-timeout` |
 | `ALLOWED_ORIGINS` | — | comma separated list of allowed CORS origins | unset (deny all) | `--allowed-origins` |
 | `BROKER_MAX_REQ_BYTES` | — | maximum MCP request size in bytes | `10485760` | — |
@@ -40,7 +40,7 @@ The worker optionally reads settings from a YAML config file. Defaults:
 | `CONFIG_FILE` | — | worker config file path | OS-specific (none on Linux) | `--config` |
 | `LOG_DIR` | — | directory for worker log files | OS-specific (none on Linux) | `--log-dir` |
 | `SERVER_URL` | `server_url` | server WebSocket URL for registration | `ws://localhost:8080/api/workers/connect` | `--server-url` |
-| `WORKER_KEY` | `worker_key` | shared secret for authenticating with the server | unset | `--worker-key` |
+| `CLIENT_KEY` | `client_key` | shared secret for authenticating with the server | unset | `--client-key` |
 | `OLLAMA_BASE_URL` | `ollama_base_url` | base URL of the local Ollama instance (`OLLAMA_URL` alias) | `http://127.0.0.1:11434` | `--ollama-base-url` |
 | `OLLAMA_URL` | `ollama_base_url` | legacy alias for `OLLAMA_BASE_URL` | same as above | — |
 | `OLLAMA_API_KEY` | — | API key for connecting to Ollama | unset | `--ollama-api-key` |
@@ -53,7 +53,7 @@ The worker optionally reads settings from a YAML config file. Defaults:
 | `WORKER_NAME` | — | worker display name | hostname (or random) | `--worker-name` |
 | `RECONNECT` | — | reconnect to server on failure | `false` | `--reconnect`, `-r` |
 
-Note: The YAML schema currently covers only a subset (`server_url`, `worker_key`, `ollama_base_url`, `max_concurrency`, `status_addr`).
+Note: The YAML schema currently covers only a subset (`server_url`, `client_key`, `ollama_base_url`, `max_concurrency`, `status_addr`).
 
 ## llamapool-mcp
 
@@ -66,6 +66,7 @@ Note: The YAML schema currently covers only a subset (`server_url`, `worker_key`
 | `CLIENT_ID` | — | client identifier (assigned when empty) | unset | — |
 | `PROVIDER_URL` | — | MCP provider URL | `http://127.0.0.1:7777/` | — |
 | `AUTH_TOKEN` | — | authorization token for broker requests | unset | — |
+| `CLIENT_KEY` | — | shared secret for authenticating with the server | unset | `--client-key` |
 | `MCP_CONFIG_FILE` | — | path to YAML config file | unset | `--mcp-config` |
 | `MCP_TRANSPORT_ORDER` | `order` | comma separated transport order | `stdio,http,oauth` | `--mcp-transport-order` |
 | `MCP_INIT_TIMEOUT` | `initTimeout` | timeout for transport startup | `5s` | `--mcp-init-timeout` |
@@ -90,7 +91,7 @@ Note: The YAML schema currently covers only a subset (`server_url`, `worker_key`
 
 ### Consistency notes
 
-`SERVER_URL`, `WORKER_KEY`, and `RECONNECT` remain shared between tools, providing predictable behavior. Metrics configuration still mixes `METRICS_PORT` on the server with `METRICS_ADDR` on the worker, and timeout variables combine duration strings (`REQUEST_TIMEOUT`) with millisecond suffixes (`BROKER_CALL_TIMEOUT_MS`). The worker's YAML config covers only a subset of its available settings, leaving items like `METRICS_ADDR` or `DRAIN_TIMEOUT` without config-file equivalents.
+`SERVER_URL`, `CLIENT_KEY`, and `RECONNECT` remain shared between tools, providing predictable behavior. Metrics configuration still mixes `METRICS_PORT` on the server with `METRICS_ADDR` on the worker, and timeout variables combine duration strings (`REQUEST_TIMEOUT`) with millisecond suffixes (`BROKER_CALL_TIMEOUT_MS`). The worker's YAML config covers only a subset of its available settings, leaving items like `METRICS_ADDR` or `DRAIN_TIMEOUT` without config-file equivalents.
 
 ### Cleanup candidates
 

--- a/docs/server-endpoints.md
+++ b/docs/server-endpoints.md
@@ -25,7 +25,7 @@ Endpoints are grouped by functional area.
 
 | Verb & Endpoint | Parameters | Description | Auth |
 | --- | --- | --- | --- |
-| `GET /api/workers/connect` (WS) | Initial message `{ type: "register", worker_key: string, worker_id?: string, worker_name?: string, models?: [string], max_concurrency?: int }` | Worker connects to server. | Worker key |
+| `GET /api/workers/connect` (WS) | Initial message `{ type: "register", client_key?: string, worker_id?: string, worker_name?: string, models?: [string], max_concurrency?: int }` | Worker connects to server. | Client key |
 
 ### Client Usage
 
@@ -42,17 +42,17 @@ Endpoints are grouped by functional area.
 
 | Verb & Endpoint | Parameters | Description | Auth |
 | --- | --- | --- | --- |
-| `POST /api/mcp/id/{id}` | Path `{id}`; Body `{ jsonrpc: "2.0", id: number|string, method: string, params?: object }` | Forward MCP JSON-RPC request to relay. | MCP token |
+| `GET /api/mcp/connect` (WS) | Initial message `{ id?: string, client_key?: string }` | MCP relay connects and receives an id. | Client key |
 
 ### Client (LLM) Usage
 
 | Verb & Endpoint | Parameters | Description | Auth |
 | --- | --- | --- | --- |
-| `POST /api/mcp/id/{id}` | Path `{id}`; Body `{ jsonrpc: "2.0", id: number|string, method: string, params?: object }` | Forward MCP JSON-RPC request to relay. | MCP token |
+| `POST /api/mcp/id/{id}` | Path `{id}`; Body `{ jsonrpc: "2.0", id: number|string, method: string, params?: object }` | Forward MCP JSON-RPC request to relay. | MCP token (optional) |
 
 ### Authentication schemes
 - **Public** – No authentication required.
 - **API key** – `Authorization: Bearer <API_KEY>`.
-- **Worker key** – WebSocket `register` message must include `worker_key` matching server configuration.
-- **MCP token** – Optional `Authorization: Bearer <AUTH_TOKEN>` forwarded to MCP relay; server does not validate.
+- **Client key** – WebSocket `register` message must include `client_key` matching server configuration. Providing a key when the server is configured without one results in an immediate failure.
+- **MCP token** – Optional `Authorization: Bearer <AUTH_TOKEN>` forwarded to the MCP relay. The server neither validates nor requires this header; if the relay is configured with a token it will reject missing or invalid tokens. Future improvements may allow the relay to signal this requirement so the server can reject unauthenticated requests early.
 

--- a/examples/llm-proxy/docker-compose.yaml
+++ b/examples/llm-proxy/docker-compose.yaml
@@ -1,6 +1,6 @@
 x-env: &common_env
   API_KEY: "test123"     # client API key for /api
-  WORKER_KEY: "secret"   # worker registration key
+  CLIENT_KEY: "secret"   # client registration key
 
 services:
   ollama:

--- a/examples/llm-proxy/example.md
+++ b/examples/llm-proxy/example.md
@@ -1,7 +1,7 @@
 ```
 x-env: &common_env
   API_KEY: "test123"     # client API key for /api
-  WORKER_KEY: "secret"   # worker registration key
+  CLIENT_KEY: "secret"   # client registration key
 
 services:
   ollama:

--- a/examples/mcp-proxy/docker-compose.yaml
+++ b/examples/mcp-proxy/docker-compose.yaml
@@ -1,6 +1,6 @@
 x-env: &common_env
   API_KEY: "test123"     # client API key for /api
-  WORKER_KEY: "secret"   # worker registration key
+  CLIENT_KEY: "secret"   # client registration key
   CLIENT_ID: mcp-1234    # a unique identifier for this mcp server
 
 services:

--- a/examples/mcp-proxy/example.md
+++ b/examples/mcp-proxy/example.md
@@ -10,7 +10,7 @@ Define the following `docker-compose.yaml`:
 ```
 x-env: &common_env
   API_KEY: "test123"     # client API key for /api
-  WORKER_KEY: "secret"   # worker registration key
+  CLIENT_KEY: "secret"   # client registration key
   CLIENT_ID: mcp-1234    # a unique identifier for this mcp server
   
 services:

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -12,7 +12,7 @@ type ServerConfig struct {
 	Port           int
 	MetricsPort    int
 	APIKey         string
-	WorkerKey      string
+	ClientKey      string
 	RequestTimeout time.Duration
 	AllowedOrigins []string
 }
@@ -25,7 +25,7 @@ func (c *ServerConfig) BindFlags() {
 	mp, _ := strconv.Atoi(getEnv("METRICS_PORT", strconv.Itoa(port)))
 	c.MetricsPort = mp
 	c.APIKey = getEnv("API_KEY", "")
-	c.WorkerKey = getEnv("WORKER_KEY", "")
+	c.ClientKey = getEnv("CLIENT_KEY", "")
 	rt, _ := time.ParseDuration(getEnv("REQUEST_TIMEOUT", "60s"))
 	c.RequestTimeout = rt
 	c.AllowedOrigins = splitComma(getEnv("ALLOWED_ORIGINS", strings.Join(c.AllowedOrigins, ",")))
@@ -33,7 +33,7 @@ func (c *ServerConfig) BindFlags() {
 	flag.IntVar(&c.Port, "port", c.Port, "HTTP listen port for the public API")
 	flag.IntVar(&c.MetricsPort, "metrics-port", c.MetricsPort, "Prometheus metrics listen port; defaults to the value of --port")
 	flag.StringVar(&c.APIKey, "api-key", c.APIKey, "client API key required for HTTP requests; leave empty to disable auth")
-	flag.StringVar(&c.WorkerKey, "worker-key", c.WorkerKey, "shared key workers must present when registering")
+	flag.StringVar(&c.ClientKey, "client-key", c.ClientKey, "shared key clients must present when registering")
 	flag.DurationVar(&c.RequestTimeout, "request-timeout", c.RequestTimeout, "maximum duration to process a client request")
 	flag.Func("allowed-origins", "comma separated list of allowed CORS origins", func(v string) error {
 		c.AllowedOrigins = splitComma(v)

--- a/internal/config/worker.go
+++ b/internal/config/worker.go
@@ -15,7 +15,7 @@ import (
 // WorkerConfig holds configuration for the worker agent.
 type WorkerConfig struct {
 	ServerURL         string
-	WorkerKey         string
+	ClientKey         string
 	OllamaBaseURL     string
 	OllamaAPIKey      string
 	MaxConcurrency    int
@@ -36,7 +36,7 @@ func (c *WorkerConfig) BindFlags() {
 	c.LogDir = getEnv("LOG_DIR", logDir)
 
 	c.ServerURL = getEnv("SERVER_URL", "ws://localhost:8080/api/workers/connect")
-	c.WorkerKey = getEnv("WORKER_KEY", "")
+	c.ClientKey = getEnv("CLIENT_KEY", "")
 	base := getEnv("OLLAMA_BASE_URL", getEnv("OLLAMA_URL", "http://127.0.0.1:11434"))
 	c.OllamaBaseURL = base
 	c.OllamaAPIKey = getEnv("OLLAMA_API_KEY", "")
@@ -70,7 +70,7 @@ func (c *WorkerConfig) BindFlags() {
 	}
 
 	flag.StringVar(&c.ServerURL, "server-url", c.ServerURL, "server WebSocket URL for registration (e.g. ws://localhost:8080/api/workers/connect)")
-	flag.StringVar(&c.WorkerKey, "worker-key", c.WorkerKey, "shared secret for authenticating with the server")
+	flag.StringVar(&c.ClientKey, "client-key", c.ClientKey, "shared secret for authenticating with the server")
 	flag.StringVar(&c.OllamaBaseURL, "ollama-base-url", c.OllamaBaseURL, "base URL of the local Ollama instance (e.g. http://127.0.0.1:11434)")
 	flag.StringVar(&c.OllamaAPIKey, "ollama-api-key", c.OllamaAPIKey, "API key for connecting to Ollama; leave empty for no auth")
 	flag.IntVar(&c.MaxConcurrency, "max-concurrency", c.MaxConcurrency, "maximum number of jobs processed concurrently")

--- a/internal/ctrl/messages.go
+++ b/internal/ctrl/messages.go
@@ -6,7 +6,8 @@ type RegisterMessage struct {
 	Type           string   `json:"type"`
 	WorkerID       string   `json:"worker_id"`
 	WorkerName     string   `json:"worker_name,omitempty"`
-	WorkerKey      string   `json:"worker_key"`
+	ClientKey      string   `json:"client_key"`
+	WorkerKey      string   `json:"worker_key,omitempty"`
 	Token          string   `json:"token,omitempty"`
 	Models         []string `json:"models"`
 	MaxConcurrency int      `json:"max_concurrency"`

--- a/internal/mcp/broker_test.go
+++ b/internal/mcp/broker_test.go
@@ -70,7 +70,7 @@ func TestHTTPHandlerConcurrencyLimit(t *testing.T) {
 func TestHTTPHandlerUnauthorized(t *testing.T) {
 	reg := NewRegistry()
 	r := chi.NewRouter()
-	r.Handle("/api/mcp/connect", reg.WSHandler())
+	r.Handle("/api/mcp/connect", reg.WSHandler(""))
 	r.Post("/api/mcp/id/{id}", reg.HTTPHandler())
 	srv := httptest.NewServer(r)
 	defer srv.Close()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -57,9 +57,9 @@ func New(reg *ctrl.Registry, metrics *ctrl.MetricsRegistry, sched ctrl.Scheduler
 	})
 	if mcpReg != nil {
 		r.Post("/api/mcp/id/{id}", mcpReg.HTTPHandler())
-		r.Handle("/api/mcp/connect", mcpReg.WSHandler())
+		r.Handle("/api/mcp/connect", mcpReg.WSHandler(cfg.ClientKey))
 	}
-	r.Handle("/api/workers/connect", ctrl.WSHandler(reg, metrics, cfg.WorkerKey))
+	r.Handle("/api/workers/connect", ctrl.WSHandler(reg, metrics, cfg.ClientKey))
 
 	metricsPort := cfg.MetricsPort
 	if metricsPort == 0 {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -103,7 +103,7 @@ func connectAndServe(ctx context.Context, cancelAll context.CancelFunc, cfg conf
 		Type:           "register",
 		WorkerID:       cfg.WorkerID,
 		WorkerName:     cfg.WorkerName,
-		WorkerKey:      cfg.WorkerKey,
+		ClientKey:      cfg.ClientKey,
 		Models:         GetState().Models,
 		MaxConcurrency: GetState().MaxConcurrency,
 		Version:        vi.Version,

--- a/test/e2e_auth_test.go
+++ b/test/e2e_auth_test.go
@@ -20,7 +20,7 @@ import (
 func TestWorkerAuth(t *testing.T) {
 	reg := ctrl.NewRegistry()
 	sched := &ctrl.LeastBusyScheduler{Reg: reg}
-	cfg := config.ServerConfig{WorkerKey: "secret", RequestTimeout: 5 * time.Second}
+	cfg := config.ServerConfig{ClientKey: "secret", RequestTimeout: 5 * time.Second}
 	metricsReg := ctrl.NewMetricsRegistry("test", "", "")
 	handler := server.New(reg, metricsReg, sched, mcp.NewRegistry(), cfg)
 	srv := httptest.NewServer(handler)
@@ -34,7 +34,7 @@ func TestWorkerAuth(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dial bad: %v", err)
 	}
-	regBad := ctrl.RegisterMessage{Type: "register", WorkerID: "wbad", WorkerKey: "nope", Models: []string{"m"}, MaxConcurrency: 1}
+	regBad := ctrl.RegisterMessage{Type: "register", WorkerID: "wbad", ClientKey: "nope", Models: []string{"m"}, MaxConcurrency: 1}
 	b, _ := json.Marshal(regBad)
 	if err := connBad.Write(ctx, websocket.MessageText, b); err != nil {
 		t.Fatalf("write bad: %v", err)
@@ -58,7 +58,7 @@ func TestWorkerAuth(t *testing.T) {
 	defer func() {
 		_ = conn.Close(websocket.StatusNormalClosure, "")
 	}()
-	regMsg := ctrl.RegisterMessage{Type: "register", WorkerID: "w1", WorkerKey: "secret", Models: []string{"m"}, MaxConcurrency: 1}
+	regMsg := ctrl.RegisterMessage{Type: "register", WorkerID: "w1", ClientKey: "secret", Models: []string{"m"}, MaxConcurrency: 1}
 	b, _ = json.Marshal(regMsg)
 	if err := conn.Write(ctx, websocket.MessageText, b); err != nil {
 		t.Fatalf("write: %v", err)
@@ -79,4 +79,94 @@ func TestWorkerAuth(t *testing.T) {
 	if err := resp.Body.Close(); err != nil {
 		t.Fatalf("close body: %v", err)
 	}
+}
+
+func TestWorkerClientKeyUnexpected(t *testing.T) {
+	reg := ctrl.NewRegistry()
+	sched := &ctrl.LeastBusyScheduler{Reg: reg}
+	cfg := config.ServerConfig{RequestTimeout: 5 * time.Second}
+	metricsReg := ctrl.NewMetricsRegistry("test", "", "")
+	handler := server.New(reg, metricsReg, sched, mcp.NewRegistry(), cfg)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	ctx := context.Background()
+	wsURL := strings.Replace(srv.URL, "http", "ws", 1) + "/api/workers/connect"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	regMsg := ctrl.RegisterMessage{Type: "register", WorkerID: "w1", ClientKey: "secret", Models: []string{"m"}, MaxConcurrency: 1}
+	b, _ := json.Marshal(regMsg)
+	if err := conn.Write(ctx, websocket.MessageText, b); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, _, err := conn.Read(ctx); err == nil {
+		t.Fatalf("expected close for unexpected key")
+	}
+	_ = conn.Close(websocket.StatusNormalClosure, "")
+}
+
+func TestMCPAuth(t *testing.T) {
+	reg := ctrl.NewRegistry()
+	sched := &ctrl.LeastBusyScheduler{Reg: reg}
+	cfg := config.ServerConfig{ClientKey: "secret", RequestTimeout: 5 * time.Second}
+	metricsReg := ctrl.NewMetricsRegistry("test", "", "")
+	mcpReg := mcp.NewRegistry()
+	handler := server.New(reg, metricsReg, sched, mcpReg, cfg)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	ctx := context.Background()
+	wsURL := strings.Replace(srv.URL, "http", "ws", 1) + "/api/mcp/connect"
+
+	connBad, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial bad: %v", err)
+	}
+	regBad := map[string]string{"id": "bad", "client_key": "nope"}
+	b, _ := json.Marshal(regBad)
+	if err := connBad.Write(ctx, websocket.MessageText, b); err != nil {
+		t.Fatalf("write bad: %v", err)
+	}
+	if _, _, err := connBad.Read(ctx); err == nil {
+		t.Fatalf("expected close for bad key")
+	}
+	_ = connBad.Close(websocket.StatusNormalClosure, "")
+
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	regMsg := map[string]string{"id": "good", "client_key": "secret"}
+	b, _ = json.Marshal(regMsg)
+	if err := conn.Write(ctx, websocket.MessageText, b); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, _, err = conn.Read(ctx)
+	if err != nil {
+		t.Fatalf("ack: %v", err)
+	}
+	_ = conn.Close(websocket.StatusNormalClosure, "")
+	srv.Close()
+
+	// unexpected key when server has none
+	cfg = config.ServerConfig{RequestTimeout: 5 * time.Second}
+	handler = server.New(reg, metricsReg, sched, mcpReg, cfg)
+	srv2 := httptest.NewServer(handler)
+	defer srv2.Close()
+	wsURL2 := strings.Replace(srv2.URL, "http", "ws", 1) + "/api/mcp/connect"
+	conn2, _, err := websocket.Dial(ctx, wsURL2, nil)
+	if err != nil {
+		t.Fatalf("dial2: %v", err)
+	}
+	regMsg2 := map[string]string{"id": "bad", "client_key": "secret"}
+	b, _ = json.Marshal(regMsg2)
+	if err := conn2.Write(ctx, websocket.MessageText, b); err != nil {
+		t.Fatalf("write2: %v", err)
+	}
+	if _, _, err := conn2.Read(ctx); err == nil {
+		t.Fatalf("expected close for unexpected key (mcp)")
+	}
+	_ = conn2.Close(websocket.StatusNormalClosure, "")
 }

--- a/test/e2e_chat_completions_proxy_test.go
+++ b/test/e2e_chat_completions_proxy_test.go
@@ -23,7 +23,7 @@ import (
 func TestE2EChatCompletionsProxy(t *testing.T) {
 	reg := ctrl.NewRegistry()
 	sched := &ctrl.LeastBusyScheduler{Reg: reg}
-	cfg := config.ServerConfig{WorkerKey: "secret", APIKey: "apikey", RequestTimeout: 5 * time.Second}
+	cfg := config.ServerConfig{ClientKey: "secret", APIKey: "apikey", RequestTimeout: 5 * time.Second}
 	metricsReg := ctrl.NewMetricsRegistry("test", "", "")
 	handler := server.New(reg, metricsReg, sched, mcp.NewRegistry(), cfg)
 	srv := httptest.NewServer(handler)
@@ -65,7 +65,7 @@ func TestE2EChatCompletionsProxy(t *testing.T) {
 	defer cancel()
 	wsURL := strings.Replace(srv.URL, "http", "ws", 1) + "/api/workers/connect"
 	go func() {
-		_ = worker.Run(ctx, config.WorkerConfig{ServerURL: wsURL, WorkerKey: "secret", OllamaBaseURL: ollama.URL, OllamaAPIKey: "secret-123", WorkerID: "w1", WorkerName: "w1", MaxConcurrency: 2})
+		_ = worker.Run(ctx, config.WorkerConfig{ServerURL: wsURL, ClientKey: "secret", OllamaBaseURL: ollama.URL, OllamaAPIKey: "secret-123", WorkerID: "w1", WorkerName: "w1", MaxConcurrency: 2})
 	}()
 
 	// wait for worker registration

--- a/test/e2e_embeddings_proxy_test.go
+++ b/test/e2e_embeddings_proxy_test.go
@@ -22,7 +22,7 @@ import (
 func TestE2EEmbeddingsProxy(t *testing.T) {
 	reg := ctrl.NewRegistry()
 	sched := &ctrl.LeastBusyScheduler{Reg: reg}
-	cfg := config.ServerConfig{WorkerKey: "secret", APIKey: "apikey", RequestTimeout: 5 * time.Second}
+	cfg := config.ServerConfig{ClientKey: "secret", APIKey: "apikey", RequestTimeout: 5 * time.Second}
 	metricsReg := ctrl.NewMetricsRegistry("test", "", "")
 	handler := server.New(reg, metricsReg, sched, mcp.NewRegistry(), cfg)
 	srv := httptest.NewServer(handler)
@@ -52,7 +52,7 @@ func TestE2EEmbeddingsProxy(t *testing.T) {
 	defer cancel()
 	wsURL := strings.Replace(srv.URL, "http", "ws", 1) + "/api/workers/connect"
 	go func() {
-		_ = worker.Run(ctx, config.WorkerConfig{ServerURL: wsURL, WorkerKey: "secret", OllamaBaseURL: ollama.URL, OllamaAPIKey: "secret-123", WorkerID: "w1", WorkerName: "w1", MaxConcurrency: 2})
+		_ = worker.Run(ctx, config.WorkerConfig{ServerURL: wsURL, ClientKey: "secret", OllamaBaseURL: ollama.URL, OllamaAPIKey: "secret-123", WorkerID: "w1", WorkerName: "w1", MaxConcurrency: 2})
 	}()
 
 	for i := 0; i < 20; i++ {

--- a/test/e2e_prune_test.go
+++ b/test/e2e_prune_test.go
@@ -19,7 +19,7 @@ import (
 func TestHeartbeatPrune(t *testing.T) {
 	reg := ctrl.NewRegistry()
 	sched := &ctrl.LeastBusyScheduler{Reg: reg}
-	cfg := config.ServerConfig{WorkerKey: "secret", RequestTimeout: 5 * time.Second}
+	cfg := config.ServerConfig{ClientKey: "secret", RequestTimeout: 5 * time.Second}
 	metricsReg := ctrl.NewMetricsRegistry("test", "", "")
 	handler := server.New(reg, metricsReg, sched, mcp.NewRegistry(), cfg)
 	srv := httptest.NewServer(handler)
@@ -32,7 +32,7 @@ func TestHeartbeatPrune(t *testing.T) {
 		t.Fatalf("dial: %v", err)
 	}
 	defer func() { _ = conn.Close(websocket.StatusNormalClosure, "") }()
-	regMsg := ctrl.RegisterMessage{Type: "register", WorkerID: "w1", WorkerKey: "secret", Models: []string{"m"}, MaxConcurrency: 1}
+	regMsg := ctrl.RegisterMessage{Type: "register", WorkerID: "w1", ClientKey: "secret", Models: []string{"m"}, MaxConcurrency: 1}
 	b, _ := json.Marshal(regMsg)
 	if err := conn.Write(ctx, websocket.MessageText, b); err != nil {
 		t.Fatalf("write: %v", err)


### PR DESCRIPTION
## Summary
- rename WORKER_KEY to CLIENT_KEY across configs, docs, and examples
- require CLIENT_KEY for both /api/workers/connect and /api/mcp/connect and reject mismatched or unexpected keys
- document and test client key authentication for workers and MCP relays

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a6b7cab2b0832c8e5ea8b8d9bb4a28