### PR TITLE
refactor: generalize completion backend config

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ The Windows service runs `llamapool-worker` with the `--reconnect` flag and shut
 - **Worker metrics** (`--metrics-addr`):
   - Exposes `llamapool_worker_*` series such as
     `llamapool_worker_connected_to_server`,
-    `llamapool_worker_connected_to_ollama`,
+    `llamapool_worker_connected_to_backend`,
     `llamapool_worker_current_jobs`,
     `llamapool_worker_max_concurrency`,
     `llamapool_worker_jobs_started_total`,
@@ -266,16 +266,16 @@ go run .\cmd\llamapool-server
 On Linux:
 
 ```bash
-SERVER_URL=ws://localhost:8080/api/workers/connect CLIENT_KEY=secret OLLAMA_BASE_URL=http://127.0.0.1:11434 WORKER_NAME=Alpha go run ./cmd/llamapool-worker
+SERVER_URL=ws://localhost:8080/api/workers/connect CLIENT_KEY=secret COMPLETION_BASE_URL=http://127.0.0.1:11434/v1 WORKER_NAME=Alpha go run ./cmd/llamapool-worker
 ```
-Optionally set `OLLAMA_API_KEY` to forward an API key to the local Ollama instance. The worker proxies requests to `${OLLAMA_BASE_URL}/v1/chat/completions`.
+Optionally set `COMPLETION_API_KEY` to forward an API key to the backend. The worker proxies requests to `${COMPLETION_BASE_URL}/chat/completions`.
 
 On Windows (CMD)
 
 ```
 set SERVER_URL=ws://localhost:8080/api/workers/connect
 set CLIENT_KEY=secret
-set OLLAMA_BASE_URL=http://127.0.0.1:11434
+set COMPLETION_BASE_URL=http://127.0.0.1:11434/v1
 go run .\cmd\llamapool-worker
 REM or if you built:
 .\bin\llamapool-worker.exe
@@ -286,7 +286,7 @@ On Windows (Powershell)
 ```
 $env:SERVER_URL = "ws://localhost:8080/api/workers/connect"
 $env:CLIENT_KEY = "secret"
-$env:OLLAMA_BASE_URL = "http://127.0.0.1:11434"
+$env:COMPLETION_BASE_URL = "http://127.0.0.1:11434/v1"
 $env:WORKER_NAME = "Alpha"
 go run .\cmd\llamapool-worker
 # or:
@@ -320,7 +320,7 @@ docker run --rm -p 8080:8080 -e CLIENT_KEY=secret -e API_KEY=test123 \
 docker run --rm \
   -e SERVER_URL=ws://localhost:8080/api/workers/connect \
   -e CLIENT_KEY=secret \
-  -e OLLAMA_BASE_URL=http://host.docker.internal:11434 \
+  -e COMPLETION_BASE_URL=http://host.docker.internal:11434/v1 \
   ghcr.io/gaspardpetit/llamapool-worker:main
 ```
 
@@ -339,7 +339,7 @@ Send `SIGTERM` again to terminate immediately. Set `--drain-timeout=0` to exit
 without waiting or `--drain-timeout=-1` to wait indefinitely.
 
 The worker polls the local Ollama instance (default every 1m) so that
-`connected_to_ollama` and `models` stay current in the `/status` output.
+`connected_to_backend` and `models` stay current in the `/status` output.
 If the model list changes, the worker proactively notifies the server so
 `/api/v1/models` reflects the latest information. Configure the poll interval
 with `MODEL_POLL_INTERVAL` or `--model-poll-interval`.

--- a/debian/examples/worker.env
+++ b/debian/examples/worker.env
@@ -2,5 +2,5 @@
 # Uncomment and set values as needed.
 # SERVER_URL=ws://localhost:8080/api/workers/connect
 # CLIENT_KEY=secret
-# OLLAMA_BASE_URL=http://127.0.0.1:11434
+# COMPLETION_BASE_URL=http://127.0.0.1:11434/v1
 # WORKER_NAME=MyWorker

--- a/deploy/systemd/worker.env.example
+++ b/deploy/systemd/worker.env.example
@@ -2,5 +2,5 @@
 # Uncomment and set values as needed.
 # SERVER_URL=ws://localhost:8080/api/workers/connect
 # CLIENT_KEY=secret
-# OLLAMA_BASE_URL=http://127.0.0.1:11434
+# COMPLETION_BASE_URL=http://127.0.0.1:11434/v1
 # WORKER_NAME=MyWorker

--- a/desktop/macos/llamapool/llamapool/PreferencesWindowController.swift
+++ b/desktop/macos/llamapool/llamapool/PreferencesWindowController.swift
@@ -4,7 +4,7 @@ class PreferencesWindowController: NSWindowController {
     private let form = NSForm(frame: NSRect(x: 20, y: 60, width: 360, height: 140))
     private var serverEntry: NSFormCell!
     private var keyEntry: NSFormCell!
-    private var ollamaEntry: NSFormCell!
+    private var completionEntry: NSFormCell!
     private var concurrencyEntry: NSFormCell!
     private var portEntry: NSFormCell!
 
@@ -18,7 +18,7 @@ class PreferencesWindowController: NSWindowController {
 
         serverEntry = form.addEntry("Server URL:")
         keyEntry = form.addEntry("Worker Key:")
-        ollamaEntry = form.addEntry("Ollama Base URL:")
+        completionEntry = form.addEntry("Completion Base URL:")
         concurrencyEntry = form.addEntry("Max Concurrency:")
         portEntry = form.addEntry("Status Port:")
         window.contentView?.addSubview(form)
@@ -33,7 +33,7 @@ class PreferencesWindowController: NSWindowController {
         let config = ConfigManager.shared.load()
         serverEntry.stringValue = config.serverURL
         keyEntry.stringValue = config.workerKey
-        ollamaEntry.stringValue = config.ollamaBaseURL
+        completionEntry.stringValue = config.completionBaseURL
         concurrencyEntry.stringValue = String(config.maxConcurrency)
         portEntry.stringValue = String(config.statusPort)
     }
@@ -53,7 +53,7 @@ class PreferencesWindowController: NSWindowController {
         }
         let config = WorkerConfig(serverURL: serverEntry.stringValue,
                                   workerKey: keyEntry.stringValue,
-                                  ollamaBaseURL: ollamaEntry.stringValue,
+                                  completionBaseURL: completionEntry.stringValue,
                                   maxConcurrency: maxConc,
                                   statusPort: port)
         guard config.isValid() else {

--- a/desktop/macos/llamapool/llamapool/StatusClient.swift
+++ b/desktop/macos/llamapool/llamapool/StatusClient.swift
@@ -13,7 +13,7 @@ struct WorkerStatus: Codable {
 
     let state: State
     let connectedToServer: Bool
-    let connectedToOllama: Bool
+    let connectedToBackend: Bool
     let currentJobs: Int
     let maxConcurrency: Int
     let models: [String]
@@ -26,7 +26,7 @@ struct WorkerStatus: Codable {
     private enum CodingKeys: String, CodingKey {
         case state
         case connectedToServer = "connected_to_server"
-        case connectedToOllama = "connected_to_ollama"
+        case connectedToBackend = "connected_to_backend"
         case currentJobs = "current_jobs"
         case maxConcurrency = "max_concurrency"
         case models

--- a/desktop/macos/llamapool/llamapool/WorkerConfig.swift
+++ b/desktop/macos/llamapool/llamapool/WorkerConfig.swift
@@ -3,14 +3,14 @@ import Foundation
 struct WorkerConfig: Equatable {
     var serverURL: String
     var clientKey: String
-    var ollamaBaseURL: String
+    var completionBaseURL: String
     var maxConcurrency: Int
     var statusPort: Int
 
-    init(serverURL: String = "", clientKey: String = "", ollamaBaseURL: String = "", maxConcurrency: Int = 1, statusPort: Int = 4555) {
+    init(serverURL: String = "", clientKey: String = "", completionBaseURL: String = "http://127.0.0.1:11434/v1", maxConcurrency: Int = 1, statusPort: Int = 4555) {
         self.serverURL = serverURL
         self.clientKey = clientKey
-        self.ollamaBaseURL = ollamaBaseURL
+        self.completionBaseURL = completionBaseURL
         self.maxConcurrency = maxConcurrency
         self.statusPort = statusPort
     }
@@ -19,7 +19,7 @@ struct WorkerConfig: Equatable {
         return """
 server_url: \(serverURL)
 client_key: \(clientKey)
-ollama_base_url: \(ollamaBaseURL)
+completion_base_url: \(completionBaseURL)
 max_concurrency: \(maxConcurrency)
 status_port: \(statusPort)
 """
@@ -35,10 +35,10 @@ status_port: \(statusPort)
         }
         let serverURL = dict["server_url"] ?? ""
         let clientKey = dict["client_key"] ?? ""
-        let ollamaBaseURL = dict["ollama_base_url"] ?? ""
+        let completionBaseURL = dict["completion_base_url"] ?? ""
         let maxConcurrency = Int(dict["max_concurrency"] ?? "1") ?? 1
         let statusPort = Int(dict["status_port"] ?? "4555") ?? 4555
-        return WorkerConfig(serverURL: serverURL, clientKey: clientKey, ollamaBaseURL: ollamaBaseURL, maxConcurrency: maxConcurrency, statusPort: statusPort)
+        return WorkerConfig(serverURL: serverURL, clientKey: clientKey, completionBaseURL: completionBaseURL, maxConcurrency: maxConcurrency, statusPort: statusPort)
     }
 
     func isValid() -> Bool {

--- a/desktop/macos/llamapool/llamapoolTests/ConfigTests.swift
+++ b/desktop/macos/llamapool/llamapoolTests/ConfigTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class ConfigTests: XCTestCase {
     func testYAMLRoundTrip() throws {
-        let config = WorkerConfig(serverURL: "wss://example", workerKey: "key", ollamaBaseURL: "http://localhost", maxConcurrency: 2, statusPort: 4555)
+        let config = WorkerConfig(serverURL: "wss://example", workerKey: "key", completionBaseURL: "http://localhost/v1", maxConcurrency: 2, statusPort: 4555)
         let yaml = config.toYAML()
         let decoded = WorkerConfig.fromYAML(yaml)
         XCTAssertEqual(config, decoded)

--- a/desktop/macos/llamapool/llamapoolTests/StatusClientTests.swift
+++ b/desktop/macos/llamapool/llamapoolTests/StatusClientTests.swift
@@ -6,7 +6,7 @@ final class StatusClientTests: XCTestCase {
     {
       "state": "connected_idle",
       "connected_to_server": true,
-      "connected_to_ollama": true,
+      "connected_to_backend": true,
       "current_jobs": 1,
       "max_concurrency": 2,
       "models": ["llama3"],

--- a/desktop/windows/Installer/worker.yaml
+++ b/desktop/windows/Installer/worker.yaml
@@ -1,6 +1,6 @@
 debug: false
 server_url: ""
 client_key: ""
-ollama_base_url: "http://127.0.0.1:11434"
+completion_base_url: "http://127.0.0.1:11434/v1"
 max_concurrency: 1
 status_addr: "127.0.0.1:4555"

--- a/desktop/windows/TrayApp.Tests/WorkerConfigTests.cs
+++ b/desktop/windows/TrayApp.Tests/WorkerConfigTests.cs
@@ -11,7 +11,7 @@ public class WorkerConfigTests
         {
             ServerUrl = "wss://example",
             ClientKey = "secret",
-            OllamaBaseUrl = "http://ollama",
+            CompletionBaseUrl = "http://ollama/v1",
             MaxConcurrency = 3,
             StatusPort = 5000
         };
@@ -22,7 +22,7 @@ public class WorkerConfigTests
             var loaded = WorkerConfig.Load(path);
             Assert.Equal(cfg.ServerUrl, loaded.ServerUrl);
             Assert.Equal(cfg.ClientKey, loaded.ClientKey);
-            Assert.Equal(cfg.OllamaBaseUrl, loaded.OllamaBaseUrl);
+            Assert.Equal(cfg.CompletionBaseUrl, loaded.CompletionBaseUrl);
             Assert.Equal(cfg.MaxConcurrency, loaded.MaxConcurrency);
             Assert.Equal(cfg.StatusPort, loaded.StatusPort);
         }

--- a/desktop/windows/TrayApp.Tests/WorkerStatusTests.cs
+++ b/desktop/windows/TrayApp.Tests/WorkerStatusTests.cs
@@ -8,7 +8,7 @@ public class WorkerStatusTests
     {
       "state": "connected_idle",
       "connected_to_server": true,
-      "connected_to_ollama": true,
+      "connected_to_backend": true,
       "current_jobs": 1,
       "max_concurrency": 2,
       "models": ["llama3"],

--- a/desktop/windows/TrayApp/PreferencesForm.cs
+++ b/desktop/windows/TrayApp/PreferencesForm.cs
@@ -7,7 +7,7 @@ public class PreferencesForm : Form
 {
     private readonly TextBox _serverUrl;
     private readonly TextBox _clientKey;
-    private readonly TextBox _ollamaUrl;
+    private readonly TextBox _completionUrl;
     private readonly NumericUpDown _maxConcurrency;
     private readonly NumericUpDown _statusPort;
 
@@ -24,7 +24,7 @@ public class PreferencesForm : Form
 
         _serverUrl = new TextBox { Dock = DockStyle.Fill, Text = config.ServerUrl };
         _clientKey = new TextBox { Dock = DockStyle.Fill, Text = config.ClientKey };
-        _ollamaUrl = new TextBox { Dock = DockStyle.Fill, Text = config.OllamaBaseUrl };
+        _completionUrl = new TextBox { Dock = DockStyle.Fill, Text = config.CompletionBaseUrl };
         _maxConcurrency = new NumericUpDown { Dock = DockStyle.Fill, Minimum = 1, Maximum = 128, Value = config.MaxConcurrency };
         _statusPort = new NumericUpDown { Dock = DockStyle.Fill, Minimum = 1, Maximum = 65535, Value = config.StatusPort };
 
@@ -36,8 +36,8 @@ public class PreferencesForm : Form
         table.Controls.Add(_serverUrl, 1, 0);
         table.Controls.Add(new Label { Text = "Client Key", Anchor = AnchorStyles.Left, AutoSize = true }, 0, 1);
         table.Controls.Add(_clientKey, 1, 1);
-        table.Controls.Add(new Label { Text = "Ollama Base URL", Anchor = AnchorStyles.Left, AutoSize = true }, 0, 2);
-        table.Controls.Add(_ollamaUrl, 1, 2);
+        table.Controls.Add(new Label { Text = "Completion Base URL", Anchor = AnchorStyles.Left, AutoSize = true }, 0, 2);
+        table.Controls.Add(_completionUrl, 1, 2);
         table.Controls.Add(new Label { Text = "Max Concurrency", Anchor = AnchorStyles.Left, AutoSize = true }, 0, 3);
         table.Controls.Add(_maxConcurrency, 1, 3);
         table.Controls.Add(new Label { Text = "Status Port", Anchor = AnchorStyles.Left, AutoSize = true }, 0, 4);
@@ -61,7 +61,7 @@ public class PreferencesForm : Form
     {
         Config.ServerUrl = _serverUrl.Text.Trim();
         Config.ClientKey = _clientKey.Text.Trim();
-        Config.OllamaBaseUrl = _ollamaUrl.Text.Trim();
+        Config.CompletionBaseUrl = _completionUrl.Text.Trim();
         Config.MaxConcurrency = (int)_maxConcurrency.Value;
         Config.StatusPort = (int)_statusPort.Value;
     }

--- a/desktop/windows/TrayApp/StatusClient.cs
+++ b/desktop/windows/TrayApp/StatusClient.cs
@@ -57,8 +57,8 @@ public record WorkerStatus(
     WorkerState State,
     [property: JsonPropertyName("connected_to_server")]
     bool ConnectedToServer,
-    [property: JsonPropertyName("connected_to_ollama")]
-    bool ConnectedToOllama,
+    [property: JsonPropertyName("connected_to_backend")]
+    bool ConnectedToBackend,
     [property: JsonPropertyName("current_jobs")]
     int CurrentJobs,
     [property: JsonPropertyName("max_concurrency")]

--- a/desktop/windows/TrayApp/TrayAppContext.cs
+++ b/desktop/windows/TrayApp/TrayAppContext.cs
@@ -158,7 +158,7 @@ public class TrayAppContext : ApplicationContext
         {
             ServerUrl = _config.ServerUrl,
             ClientKey = _config.ClientKey,
-            OllamaBaseUrl = _config.OllamaBaseUrl,
+            CompletionBaseUrl = _config.CompletionBaseUrl,
             MaxConcurrency = _config.MaxConcurrency,
             StatusPort = _config.StatusPort
         });
@@ -473,7 +473,7 @@ public class TrayAppContext : ApplicationContext
             var msg = $"Worker: {s.WorkerName} ({s.WorkerId})\n" +
                       $"Version: {s.Version}\n" +
                       $"Connected to server: {s.ConnectedToServer}\n" +
-                      $"Connected to Ollama: {s.ConnectedToOllama}\n" +
+                    $"Connected to Backend: {s.ConnectedToBackend}\n" +
                       $"Jobs: {s.CurrentJobs}/{s.MaxConcurrency}\n" +
                       $"Last error: {(string.IsNullOrEmpty(s.LastError) ? "<none>" : s.LastError)}";
             MessageBox.Show(msg, "Worker Details");

--- a/desktop/windows/TrayApp/WorkerConfig.cs
+++ b/desktop/windows/TrayApp/WorkerConfig.cs
@@ -8,7 +8,7 @@ public class WorkerConfig
 {
     public string ServerUrl { get; set; } = "";
     public string ClientKey { get; set; } = "";
-    public string OllamaBaseUrl { get; set; } = "http://127.0.0.1:11434";
+    public string CompletionBaseUrl { get; set; } = "http://127.0.0.1:11434/v1";
     public int MaxConcurrency { get; set; } = 2;
 
     public string StatusAddr

--- a/doc/env.md
+++ b/doc/env.md
@@ -41,9 +41,8 @@ The worker optionally reads settings from a YAML config file. Defaults:
 | `LOG_DIR` | — | directory for worker log files | OS-specific (none on Linux) | `--log-dir` |
 | `SERVER_URL` | `server_url` | server WebSocket URL for registration | `ws://localhost:8080/api/workers/connect` | `--server-url` |
 | `CLIENT_KEY` | `client_key` | shared secret for authenticating with the server | unset | `--client-key` |
-| `OLLAMA_BASE_URL` | `ollama_base_url` | base URL of the local Ollama instance (`OLLAMA_URL` alias) | `http://127.0.0.1:11434` | `--ollama-base-url` |
-| `OLLAMA_URL` | `ollama_base_url` | legacy alias for `OLLAMA_BASE_URL` | same as above | — |
-| `OLLAMA_API_KEY` | — | API key for connecting to Ollama | unset | `--ollama-api-key` |
+| `COMPLETION_BASE_URL` | `completion_base_url` | base URL of the completion API (`OLLAMA_BASE_URL` alias) | `http://127.0.0.1:11434/v1` | `--completion-base-url` |
+| `COMPLETION_API_KEY` | — | API key for the completion API | unset | `--completion-api-key` |
 | `MAX_CONCURRENCY` | `max_concurrency` | maximum number of jobs processed concurrently | `2` | `--max-concurrency` |
 | `WORKER_ID` | — | worker identifier (random if unset) | unset | `--worker-id` |
 | `STATUS_ADDR` | `status_addr` | local status HTTP listen address | unset (disabled) | `--status-addr` |
@@ -53,7 +52,7 @@ The worker optionally reads settings from a YAML config file. Defaults:
 | `WORKER_NAME` | — | worker display name | hostname (or random) | `--worker-name` |
 | `RECONNECT` | — | reconnect to server on failure | `false` | `--reconnect`, `-r` |
 
-Note: The YAML schema currently covers only a subset (`server_url`, `client_key`, `ollama_base_url`, `max_concurrency`, `status_addr`).
+Note: The YAML schema currently covers only a subset (`server_url`, `client_key`, `completion_base_url`, `max_concurrency`, `status_addr`).
 
 ## llamapool-mcp
 
@@ -97,7 +96,7 @@ Note: The YAML schema currently covers only a subset (`server_url`, `client_key`
 
 | Option(s) | Issue | Recommendation |
 |-----------|-------|----------------|
-| `OLLAMA_URL` | legacy alias for `OLLAMA_BASE_URL` | consolidate on `OLLAMA_BASE_URL` |
+| `OLLAMA_URL`, `OLLAMA_BASE_URL` | legacy aliases for `COMPLETION_BASE_URL` | consolidate on `COMPLETION_BASE_URL` |
 | `METRICS_PORT` / `METRICS_ADDR` | inconsistent metrics naming | standardize on a single form (e.g., address) |
 | `BROKER_CALL_TIMEOUT_MS` vs `REQUEST_TIMEOUT` | mixed units and naming for timeouts | use duration strings consistently |
 | `CONFIG_FILE` / `MCP_CONFIG_FILE` | inconsistent config file naming | adopt a consistent `*_CONFIG_FILE` pattern |

--- a/examples/llm-proxy/docker-compose.yaml
+++ b/examples/llm-proxy/docker-compose.yaml
@@ -26,7 +26,7 @@ services:
     environment:
       <<: *common_env
       SERVER_URL: "ws://server:8080/api/workers/connect"
-      OLLAMA_BASE_URL: "http://ollama:11434"
+      COMPLETION_BASE_URL: "http://ollama:11434/v1"
       WORKER_NAME: "Alpha"
       STATUS_ADDR: "0.0.0.0:4555"
     ports:

--- a/examples/llm-proxy/example.md
+++ b/examples/llm-proxy/example.md
@@ -28,7 +28,7 @@ services:
     environment:
       <<: *common_env
       SERVER_URL: "ws://server:8080/api/workers/connect"
-      OLLAMA_BASE_URL: "http://ollama:11434"
+      COMPLETION_BASE_URL: "http://ollama:11434/v1"
       WORKER_NAME: "Alpha"
       STATUS_ADDR: "0.0.0.0:4555"
     ports:

--- a/internal/api/chat_completions.go
+++ b/internal/api/chat_completions.go
@@ -80,7 +80,7 @@ func ChatCompletionsHandler(reg *ctrl.Registry, sched ctrl.Scheduler, metricsReg
 			Type:      "http_proxy_request",
 			RequestID: reqID,
 			Method:    http.MethodPost,
-			Path:      "/v1/chat/completions",
+			Path:      "/chat/completions",
 			Headers:   headers,
 			Stream:    meta.Stream,
 			Body:      body,

--- a/internal/api/embeddings.go
+++ b/internal/api/embeddings.go
@@ -79,7 +79,7 @@ func EmbeddingsHandler(reg *ctrl.Registry, sched ctrl.Scheduler, metricsReg *ctr
 			Type:      "http_proxy_request",
 			RequestID: reqID,
 			Method:    http.MethodPost,
-			Path:      "/v1/embeddings",
+			Path:      "/embeddings",
 			Headers:   headers,
 			Stream:    false,
 			Body:      body,

--- a/internal/config/worker.go
+++ b/internal/config/worker.go
@@ -16,8 +16,8 @@ import (
 type WorkerConfig struct {
 	ServerURL         string
 	ClientKey         string
-	OllamaBaseURL     string
-	OllamaAPIKey      string
+	CompletionBaseURL string
+	CompletionAPIKey  string
 	MaxConcurrency    int
 	WorkerID          string
 	WorkerName        string
@@ -37,9 +37,9 @@ func (c *WorkerConfig) BindFlags() {
 
 	c.ServerURL = getEnv("SERVER_URL", "ws://localhost:8080/api/workers/connect")
 	c.ClientKey = getEnv("CLIENT_KEY", "")
-	base := getEnv("OLLAMA_BASE_URL", getEnv("OLLAMA_URL", "http://127.0.0.1:11434"))
-	c.OllamaBaseURL = base
-	c.OllamaAPIKey = getEnv("OLLAMA_API_KEY", "")
+	base := getEnv("COMPLETION_BASE_URL", getEnv("OLLAMA_BASE_URL", getEnv("OLLAMA_URL", "http://127.0.0.1:11434/v1")))
+	c.CompletionBaseURL = base
+	c.CompletionAPIKey = getEnv("COMPLETION_API_KEY", getEnv("OLLAMA_API_KEY", ""))
 	mc := getEnv("MAX_CONCURRENCY", "2")
 	if v, err := strconv.Atoi(mc); err == nil {
 		c.MaxConcurrency = v
@@ -71,8 +71,8 @@ func (c *WorkerConfig) BindFlags() {
 
 	flag.StringVar(&c.ServerURL, "server-url", c.ServerURL, "server WebSocket URL for registration (e.g. ws://localhost:8080/api/workers/connect)")
 	flag.StringVar(&c.ClientKey, "client-key", c.ClientKey, "shared secret for authenticating with the server")
-	flag.StringVar(&c.OllamaBaseURL, "ollama-base-url", c.OllamaBaseURL, "base URL of the local Ollama instance (e.g. http://127.0.0.1:11434)")
-	flag.StringVar(&c.OllamaAPIKey, "ollama-api-key", c.OllamaAPIKey, "API key for connecting to Ollama; leave empty for no auth")
+	flag.StringVar(&c.CompletionBaseURL, "completion-base-url", c.CompletionBaseURL, "base URL of the completion API (e.g. http://127.0.0.1:11434/v1)")
+	flag.StringVar(&c.CompletionAPIKey, "completion-api-key", c.CompletionAPIKey, "API key for the completion API; leave empty for no auth")
 	flag.IntVar(&c.MaxConcurrency, "max-concurrency", c.MaxConcurrency, "maximum number of jobs processed concurrently")
 	flag.StringVar(&c.WorkerID, "worker-id", c.WorkerID, "worker identifier; randomly generated if omitted")
 	flag.StringVar(&c.WorkerName, "worker-name", c.WorkerName, "worker display name shown in logs and status")
@@ -81,7 +81,7 @@ func (c *WorkerConfig) BindFlags() {
 	flag.StringVar(&c.ConfigFile, "config", c.ConfigFile, "worker config file path")
 	flag.StringVar(&c.LogDir, "log-dir", c.LogDir, "directory for worker log files")
 	flag.DurationVar(&c.DrainTimeout, "drain-timeout", c.DrainTimeout, "time to wait for in-flight jobs on shutdown (-1 to wait indefinitely, 0 to exit immediately)")
-	flag.DurationVar(&c.ModelPollInterval, "model-poll-interval", c.ModelPollInterval, "interval for polling Ollama for model changes")
+	flag.DurationVar(&c.ModelPollInterval, "model-poll-interval", c.ModelPollInterval, "interval for polling backend for model changes")
 	flag.BoolVar(&c.Reconnect, "reconnect", c.Reconnect, "reconnect to server on failure")
 	flag.BoolVar(&c.Reconnect, "r", c.Reconnect, "short for --reconnect")
 }

--- a/internal/worker/drain_integration_test.go
+++ b/internal/worker/drain_integration_test.go
@@ -54,7 +54,7 @@ func TestDrainAndTerminate(t *testing.T) {
 	statusAddr := ln.Addr().String()
 	_ = ln.Close()
 
-	cfg := config.WorkerConfig{ServerURL: wsURL, OllamaBaseURL: ollama.URL, MaxConcurrency: 1, StatusAddr: statusAddr, ConfigFile: filepath.Join(t.TempDir(), "worker.yaml")}
+	cfg := config.WorkerConfig{ServerURL: wsURL, CompletionBaseURL: ollama.URL + "/v1", MaxConcurrency: 1, StatusAddr: statusAddr, ConfigFile: filepath.Join(t.TempDir(), "worker.yaml")}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	errCh := make(chan error, 1)
@@ -151,7 +151,7 @@ func TestDrainTerminatesWhenIdle(t *testing.T) {
 	defer srv.Close()
 	wsURL := "ws://" + srv.Listener.Addr().String()
 
-	cfg := config.WorkerConfig{ServerURL: wsURL, OllamaBaseURL: ollama.URL, MaxConcurrency: 1}
+	cfg := config.WorkerConfig{ServerURL: wsURL, CompletionBaseURL: ollama.URL + "/v1", MaxConcurrency: 1}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	errCh := make(chan error, 1)

--- a/internal/worker/http_proxy.go
+++ b/internal/worker/http_proxy.go
@@ -35,7 +35,7 @@ func handleHTTPProxy(ctx context.Context, cfg config.WorkerConfig, sendCh chan [
 	}()
 
 	logx.Log.Info().Str("request_id", req.RequestID).Msg("proxy start")
-	url := cfg.OllamaBaseURL + req.Path
+	url := cfg.CompletionBaseURL + req.Path
 	if req.Stream {
 		if strings.Contains(url, "?") {
 			url += "&stream=true"
@@ -54,8 +54,8 @@ func handleHTTPProxy(ctx context.Context, cfg config.WorkerConfig, sendCh chan [
 		}
 		httpReq.Header.Set(k, v)
 	}
-	if cfg.OllamaAPIKey != "" {
-		httpReq.Header.Set("Authorization", "Bearer "+cfg.OllamaAPIKey)
+	if cfg.CompletionAPIKey != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+cfg.CompletionAPIKey)
 	}
 	httpReq.Header.Set("Connection", "close")
 

--- a/internal/worker/http_proxy_test.go
+++ b/internal/worker/http_proxy_test.go
@@ -45,11 +45,11 @@ func TestHandleHTTPProxyAuthAndStream(t *testing.T) {
 	}))
 	defer ollama.Close()
 
-	cfg := config.WorkerConfig{OllamaBaseURL: ollama.URL, OllamaAPIKey: "secret-123"}
+	cfg := config.WorkerConfig{CompletionBaseURL: ollama.URL + "/v1", CompletionAPIKey: "secret-123"}
 	sendCh := make(chan []byte, 16)
 	cancels := make(map[string]context.CancelFunc)
 	var mu sync.Mutex
-	req := ctrl.HTTPProxyRequestMessage{Type: "http_proxy_request", RequestID: "r1", Method: http.MethodPost, Path: "/v1/chat/completions", Headers: map[string]string{"Content-Type": "application/json"}, Stream: true, Body: []byte(`{}`)}
+	req := ctrl.HTTPProxyRequestMessage{Type: "http_proxy_request", RequestID: "r1", Method: http.MethodPost, Path: "/chat/completions", Headers: map[string]string{"Content-Type": "application/json"}, Stream: true, Body: []byte(`{}`)}
 	ctx := context.Background()
 	go handleHTTPProxy(ctx, cfg, sendCh, req, cancels, &mu, func() {})
 

--- a/internal/worker/metrics.go
+++ b/internal/worker/metrics.go
@@ -16,9 +16,9 @@ var (
 		Name: "llamapool_worker_connected_to_server",
 		Help: "Whether the worker is connected to the server (1 or 0)",
 	})
-	connectedToOllamaGauge = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "llamapool_worker_connected_to_ollama",
-		Help: "Whether the worker can reach its Ollama backend (1 or 0)",
+	connectedToBackendGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "llamapool_worker_connected_to_backend",
+		Help: "Whether the worker can reach its completion backend (1 or 0)",
 	})
 	currentJobsGauge = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "llamapool_worker_current_jobs",
@@ -53,7 +53,7 @@ func StartMetricsServer(ctx context.Context, addr string) (string, error) {
 	reg := prometheus.NewRegistry()
 	reg.MustRegister(
 		connectedToServerGauge,
-		connectedToOllamaGauge,
+		connectedToBackendGauge,
 		currentJobsGauge,
 		maxConcurrencyGauge,
 		jobsStartedCounter,
@@ -92,11 +92,11 @@ func setConnectedToServer(v bool) {
 	}
 }
 
-func setConnectedToOllama(v bool) {
+func setConnectedToBackend(v bool) {
 	if v {
-		connectedToOllamaGauge.Set(1)
+		connectedToBackendGauge.Set(1)
 	} else {
-		connectedToOllamaGauge.Set(0)
+		connectedToBackendGauge.Set(0)
 	}
 }
 

--- a/internal/worker/metrics_test.go
+++ b/internal/worker/metrics_test.go
@@ -13,7 +13,7 @@ func TestMetricsServer(t *testing.T) {
 	resetState()
 	SetWorkerInfo("id1", "worker", 2, nil)
 	SetConnectedToServer(true)
-	SetConnectedToOllama(true)
+	SetConnectedToBackend(true)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	addr, err := StartMetricsServer(ctx, "127.0.0.1:0")
@@ -31,6 +31,9 @@ func TestMetricsServer(t *testing.T) {
 	data := string(body)
 	if !strings.Contains(data, "llamapool_worker_connected_to_server 1") {
 		t.Fatalf("missing connected_to_server gauge: %s", data)
+	}
+	if !strings.Contains(data, "llamapool_worker_connected_to_backend 1") {
+		t.Fatalf("missing connected_to_backend gauge: %s", data)
 	}
 	if !strings.Contains(data, "llamapool_worker_jobs_started_total") {
 		t.Fatalf("missing jobs_started_total counter: %s", data)

--- a/internal/worker/status.go
+++ b/internal/worker/status.go
@@ -7,17 +7,17 @@ import (
 )
 
 type State struct {
-	State             string    `json:"state"`
-	ConnectedToServer bool      `json:"connected_to_server"`
-	ConnectedToOllama bool      `json:"connected_to_ollama"`
-	CurrentJobs       int       `json:"current_jobs"`
-	MaxConcurrency    int       `json:"max_concurrency"`
-	Models            []string  `json:"models"`
-	LastError         string    `json:"last_error"`
-	LastHeartbeat     time.Time `json:"last_heartbeat"`
-	WorkerID          string    `json:"worker_id"`
-	WorkerName        string    `json:"worker_name"`
-	Version           string    `json:"version"`
+	State              string    `json:"state"`
+	ConnectedToServer  bool      `json:"connected_to_server"`
+	ConnectedToBackend bool      `json:"connected_to_backend"`
+	CurrentJobs        int       `json:"current_jobs"`
+	MaxConcurrency     int       `json:"max_concurrency"`
+	Models             []string  `json:"models"`
+	LastError          string    `json:"last_error"`
+	LastHeartbeat      time.Time `json:"last_heartbeat"`
+	WorkerID           string    `json:"worker_id"`
+	WorkerName         string    `json:"worker_name"`
+	Version            string    `json:"version"`
 }
 
 type VersionInfo struct {
@@ -79,11 +79,11 @@ func SetConnectedToServer(v bool) {
 	setConnectedToServer(v)
 }
 
-func SetConnectedToOllama(v bool) {
+func SetConnectedToBackend(v bool) {
 	stateMu.Lock()
-	stateData.ConnectedToOllama = v
+	stateData.ConnectedToBackend = v
 	stateMu.Unlock()
-	setConnectedToOllama(v)
+	setConnectedToBackend(v)
 }
 
 func SetModels(models []string) {

--- a/test/e2e_chat_completions_proxy_test.go
+++ b/test/e2e_chat_completions_proxy_test.go
@@ -65,7 +65,7 @@ func TestE2EChatCompletionsProxy(t *testing.T) {
 	defer cancel()
 	wsURL := strings.Replace(srv.URL, "http", "ws", 1) + "/api/workers/connect"
 	go func() {
-		_ = worker.Run(ctx, config.WorkerConfig{ServerURL: wsURL, ClientKey: "secret", OllamaBaseURL: ollama.URL, OllamaAPIKey: "secret-123", WorkerID: "w1", WorkerName: "w1", MaxConcurrency: 2})
+		_ = worker.Run(ctx, config.WorkerConfig{ServerURL: wsURL, ClientKey: "secret", CompletionBaseURL: ollama.URL + "/v1", CompletionAPIKey: "secret-123", WorkerID: "w1", WorkerName: "w1", MaxConcurrency: 2})
 	}()
 
 	// wait for worker registration

--- a/test/e2e_embeddings_proxy_test.go
+++ b/test/e2e_embeddings_proxy_test.go
@@ -52,7 +52,7 @@ func TestE2EEmbeddingsProxy(t *testing.T) {
 	defer cancel()
 	wsURL := strings.Replace(srv.URL, "http", "ws", 1) + "/api/workers/connect"
 	go func() {
-		_ = worker.Run(ctx, config.WorkerConfig{ServerURL: wsURL, ClientKey: "secret", OllamaBaseURL: ollama.URL, OllamaAPIKey: "secret-123", WorkerID: "w1", WorkerName: "w1", MaxConcurrency: 2})
+		_ = worker.Run(ctx, config.WorkerConfig{ServerURL: wsURL, ClientKey: "secret", CompletionBaseURL: ollama.URL + "/v1", CompletionAPIKey: "secret-123", WorkerID: "w1", WorkerName: "w1", MaxConcurrency: 2})
 	}()
 
 	for i := 0; i < 20; i++ {


### PR DESCRIPTION
## Summary
- consolidate completion backend configuration via `COMPLETION_BASE_URL` and `COMPLETION_API_KEY`
- proxy completions and embeddings against generic `/chat/completions` and `/embeddings` paths
- expose backend connectivity through `connected_to_backend` state and metrics

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a6c7c3d1f4832cb640394a9db10777