### PR TITLE
unify metrics port configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ The Windows service runs `llamapool-worker` with the `--reconnect` flag and shut
 - llamapool API:
   - **State (JSON):** `GET /api/state`
   - **State (SSE):** `GET /api/state/stream`
-- Prometheus metrics: `GET /metrics` (serve on separate port via `METRICS_PORT` or `--metrics-port`)
+- Prometheus metrics: `GET /metrics` (serve on separate address via `METRICS_PORT` or `--metrics-port`)
 - API docs:
   - Swagger UI: `GET /api/client/`
   - OpenAPI schema: `GET /api/client/openapi.json`
@@ -153,13 +153,13 @@ The Windows service runs `llamapool-worker` with the `--reconnect` flag and shut
 
 ## Monitoring & Observability
 
-- **Prometheus** (`/metrics`, configurable port via `METRICS_PORT` or `--metrics-port`):
+- **Prometheus** (`/metrics`, configurable address via `METRICS_PORT` or `--metrics-port`):
   - `llamapool_build_info{component="server",version,sha,date}`
   - `llamapool_model_requests_total{model,outcome}`
   - `llamapool_model_tokens_total{model,kind}`
   - `llamapool_request_duration_seconds{worker_id,model}` (histogram)
   - (Optionally) per-worker gauges/counters if enabled.
-- **Worker metrics** (`--metrics-addr`):
+- **Worker metrics** (`METRICS_PORT` or `--metrics-port`):
   - Exposes `llamapool_worker_*` series such as
     `llamapool_worker_connected_to_server`,
     `llamapool_worker_connected_to_ollama`,
@@ -169,6 +169,8 @@ The Windows service runs `llamapool-worker` with the `--reconnect` flag and shut
     `llamapool_worker_jobs_succeeded_total`,
     `llamapool_worker_jobs_failed_total`, and
     `llamapool_worker_job_duration_seconds` (histogram).
+- **MCP relay metrics** (`METRICS_PORT` or `--metrics-port`):
+  - Exposes basic Go runtime metrics.
 
 - **JSON/SSE State** (`/api/state`, `/api/state/stream`): suitable for custom dashboards showing:
   - worker list and status (connected/working/idle/gone)

--- a/cmd/llamapool-mcp/main.go
+++ b/cmd/llamapool-mcp/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/coder/websocket"
@@ -102,6 +103,8 @@ func main() {
 	flag.BoolVar(&reconnectFlag, "r", reconnectFlag, "short for --reconnect")
 	clientKey := getEnv("CLIENT_KEY", "")
 	flag.StringVar(&clientKey, "client-key", clientKey, "shared secret for authenticating with the server")
+	metricsAddr := getEnv("METRICS_PORT", "")
+	flag.StringVar(&metricsAddr, "metrics-port", metricsAddr, "Prometheus metrics listen address or port (disabled when empty; e.g. 127.0.0.1:9090 or 9090)")
 	flag.Parse()
 	if *showVersion {
 		fmt.Printf("llamapool-mcp version=%s sha=%s date=%s\n", version, buildSHA, buildDate)
@@ -113,6 +116,16 @@ func main() {
 	providerURL := getEnv("PROVIDER_URL", "http://127.0.0.1:7777/")
 	authToken := getEnv("AUTH_TOKEN", "")
 	header := http.Header{}
+
+	if metricsAddr != "" {
+		if !strings.Contains(metricsAddr, ":") {
+			metricsAddr = ":" + metricsAddr
+		}
+		if _, err := mcp.StartMetricsServer(context.Background(), metricsAddr); err != nil {
+			logx.Log.Fatal().Err(err).Msg("metrics server")
+		}
+		logx.Log.Info().Str("addr", metricsAddr).Msg("metrics server started")
+	}
 
 	attempt := 0
 	for {

--- a/cmd/llamapool-server/main.go
+++ b/cmd/llamapool-server/main.go
@@ -59,10 +59,10 @@ func main() {
 	handler := server.New(reg, metricsReg, sched, mcpReg, cfg)
 	srv := &http.Server{Addr: fmt.Sprintf(":%d", cfg.Port), Handler: handler}
 	var metricsSrv *http.Server
-	if cfg.MetricsPort != cfg.Port {
+	if cfg.MetricsAddr != fmt.Sprintf(":%d", cfg.Port) {
 		mux := http.NewServeMux()
 		mux.Handle("/metrics", promhttp.Handler())
-		metricsSrv = &http.Server{Addr: fmt.Sprintf(":%d", cfg.MetricsPort), Handler: mux}
+		metricsSrv = &http.Server{Addr: cfg.MetricsAddr, Handler: mux}
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
@@ -91,7 +91,7 @@ func main() {
 	logx.Log.Info().Int("port", cfg.Port).Msg("server starting")
 	if metricsSrv != nil {
 		go func() {
-			logx.Log.Info().Int("port", cfg.MetricsPort).Msg("metrics server starting")
+			logx.Log.Info().Str("addr", cfg.MetricsAddr).Msg("metrics server starting")
 			if err := metricsSrv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 				logx.Log.Error().Err(err).Msg("metrics server error")
 			}

--- a/doc/env.md
+++ b/doc/env.md
@@ -15,7 +15,7 @@ llamapool-server does not currently read from a configuration file; settings are
 | Variable | Config key | Purpose | Default | CLI flag |
 |----------|------------|---------|---------|----------|
 | `PORT` | — | HTTP listen port for the public API | `8080` | `--port` |
-| `METRICS_PORT` | — | Prometheus metrics listen port | same as `PORT` | `--metrics-port` |
+| `METRICS_PORT` | — | Prometheus metrics listen address or port | same as `PORT` | `--metrics-port` |
 | `API_KEY` | — | client API key required for HTTP requests | unset (auth disabled) | `--api-key` |
 | `CLIENT_KEY` | — | shared key clients must present when registering | unset | `--client-key` |
 | `REQUEST_TIMEOUT` | — | maximum duration to process a client request | `60s` | `--request-timeout` |
@@ -47,7 +47,7 @@ The worker optionally reads settings from a YAML config file. Defaults:
 | `MAX_CONCURRENCY` | `max_concurrency` | maximum number of jobs processed concurrently | `2` | `--max-concurrency` |
 | `WORKER_ID` | — | worker identifier (random if unset) | unset | `--worker-id` |
 | `STATUS_ADDR` | `status_addr` | local status HTTP listen address | unset (disabled) | `--status-addr` |
-| `METRICS_ADDR` | — | Prometheus metrics listen address | unset (disabled) | `--metrics-addr` |
+| `METRICS_PORT` | — | Prometheus metrics listen address or port | unset (disabled) | `--metrics-port` |
 | `DRAIN_TIMEOUT` | — | time to wait for in-flight jobs on shutdown | `1m` | `--drain-timeout` |
 | `MODEL_POLL_INTERVAL` | — | interval for polling Ollama for model changes | `1m` | `--model-poll-interval` |
 | `WORKER_NAME` | — | worker display name | hostname (or random) | `--worker-name` |
@@ -68,6 +68,7 @@ Note: The YAML schema currently covers only a subset (`server_url`, `client_key`
 | `AUTH_TOKEN` | — | authorization token for broker requests | unset | — |
 | `CLIENT_KEY` | — | shared secret for authenticating with the server | unset | `--client-key` |
 | `MCP_CONFIG_FILE` | — | path to YAML config file | unset | `--mcp-config` |
+| `METRICS_PORT` | — | Prometheus metrics listen address or port | unset (disabled) | `--metrics-port` |
 | `MCP_TRANSPORT_ORDER` | `order` | comma separated transport order | `stdio,http,oauth` | `--mcp-transport-order` |
 | `MCP_INIT_TIMEOUT` | `initTimeout` | timeout for transport startup | `5s` | `--mcp-init-timeout` |
 | `MCP_PROTOCOL_VERSION` | `protocolVersion` | preferred MCP protocol version | negotiated automatically | `--mcp-protocol-version` |
@@ -91,14 +92,13 @@ Note: The YAML schema currently covers only a subset (`server_url`, `client_key`
 
 ### Consistency notes
 
-`SERVER_URL`, `CLIENT_KEY`, and `RECONNECT` remain shared between tools, providing predictable behavior. Metrics configuration still mixes `METRICS_PORT` on the server with `METRICS_ADDR` on the worker, and timeout variables combine duration strings (`REQUEST_TIMEOUT`) with millisecond suffixes (`BROKER_CALL_TIMEOUT_MS`). The worker's YAML config covers only a subset of its available settings, leaving items like `METRICS_ADDR` or `DRAIN_TIMEOUT` without config-file equivalents.
+`SERVER_URL`, `CLIENT_KEY`, and `RECONNECT` remain shared between tools, providing predictable behavior. Timeout variables still mix duration strings (`REQUEST_TIMEOUT`) with millisecond suffixes (`BROKER_CALL_TIMEOUT_MS`). The worker's YAML config covers only a subset of its available settings, leaving items like `METRICS_PORT` or `DRAIN_TIMEOUT` without config-file equivalents.
 
 ### Cleanup candidates
 
 | Option(s) | Issue | Recommendation |
 |-----------|-------|----------------|
 | `OLLAMA_URL` | legacy alias for `OLLAMA_BASE_URL` | consolidate on `OLLAMA_BASE_URL` |
-| `METRICS_PORT` / `METRICS_ADDR` | inconsistent metrics naming | standardize on a single form (e.g., address) |
 | `BROKER_CALL_TIMEOUT_MS` vs `REQUEST_TIMEOUT` | mixed units and naming for timeouts | use duration strings consistently |
 | `CONFIG_FILE` / `MCP_CONFIG_FILE` | inconsistent config file naming | adopt a consistent `*_CONFIG_FILE` pattern |
 | worker YAML coverage | config file omits many settings (metrics, timeouts, names) | expand or deprecate partial config schema |

--- a/doc/server-endpoints.md
+++ b/doc/server-endpoints.md
@@ -7,7 +7,7 @@ Endpoints are grouped by functional area.
 | Verb & Endpoint | Parameters | Description | Auth |
 | --- | --- | --- | --- |
 | `GET /healthz` | – | Basic health check. | Public |
-| `GET /metrics` | – | Prometheus metrics (`METRICS_PORT` env or `--metrics-port` flag for separate port). | Public |
+| `GET /metrics` | – | Prometheus metrics (`METRICS_PORT` env or `--metrics-port` flag for separate address). | Public |
 | `GET /api/client/openapi.json` | – | OpenAPI schema. | Public |
 | `GET /api/client/*` | – | Swagger UI. | Public |
 

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"flag"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -10,7 +11,7 @@ import (
 // ServerConfig holds configuration for the llamapool server.
 type ServerConfig struct {
 	Port           int
-	MetricsPort    int
+	MetricsAddr    string
 	APIKey         string
 	ClientKey      string
 	RequestTimeout time.Duration
@@ -22,8 +23,14 @@ type ServerConfig struct {
 func (c *ServerConfig) BindFlags() {
 	port, _ := strconv.Atoi(getEnv("PORT", "8080"))
 	c.Port = port
-	mp, _ := strconv.Atoi(getEnv("METRICS_PORT", strconv.Itoa(port)))
-	c.MetricsPort = mp
+	mp := getEnv("METRICS_PORT", "")
+	if mp == "" {
+		c.MetricsAddr = fmt.Sprintf(":%d", port)
+	} else if strings.Contains(mp, ":") {
+		c.MetricsAddr = mp
+	} else {
+		c.MetricsAddr = ":" + mp
+	}
 	c.APIKey = getEnv("API_KEY", "")
 	c.ClientKey = getEnv("CLIENT_KEY", "")
 	rt, _ := time.ParseDuration(getEnv("REQUEST_TIMEOUT", "60s"))
@@ -31,7 +38,7 @@ func (c *ServerConfig) BindFlags() {
 	c.AllowedOrigins = splitComma(getEnv("ALLOWED_ORIGINS", strings.Join(c.AllowedOrigins, ",")))
 
 	flag.IntVar(&c.Port, "port", c.Port, "HTTP listen port for the public API")
-	flag.IntVar(&c.MetricsPort, "metrics-port", c.MetricsPort, "Prometheus metrics listen port; defaults to the value of --port")
+	flag.StringVar(&c.MetricsAddr, "metrics-port", c.MetricsAddr, "Prometheus metrics listen address or port; defaults to the value of --port")
 	flag.StringVar(&c.APIKey, "api-key", c.APIKey, "client API key required for HTTP requests; leave empty to disable auth")
 	flag.StringVar(&c.ClientKey, "client-key", c.ClientKey, "shared key clients must present when registering")
 	flag.DurationVar(&c.RequestTimeout, "request-timeout", c.RequestTimeout, "maximum duration to process a client request")

--- a/internal/config/worker.go
+++ b/internal/config/worker.go
@@ -48,7 +48,11 @@ func (c *WorkerConfig) BindFlags() {
 	}
 	c.WorkerID = getEnv("WORKER_ID", "")
 	c.StatusAddr = getEnv("STATUS_ADDR", "")
-	c.MetricsAddr = getEnv("METRICS_ADDR", "")
+	mp := getEnv("METRICS_PORT", "")
+	if mp != "" && !strings.Contains(mp, ":") {
+		mp = ":" + mp
+	}
+	c.MetricsAddr = mp
 	if d, err := time.ParseDuration(getEnv("DRAIN_TIMEOUT", "1m")); err == nil {
 		c.DrainTimeout = d
 	} else {
@@ -77,7 +81,7 @@ func (c *WorkerConfig) BindFlags() {
 	flag.StringVar(&c.WorkerID, "worker-id", c.WorkerID, "worker identifier; randomly generated if omitted")
 	flag.StringVar(&c.WorkerName, "worker-name", c.WorkerName, "worker display name shown in logs and status")
 	flag.StringVar(&c.StatusAddr, "status-addr", c.StatusAddr, "local status HTTP listen address (enables /status; e.g. 127.0.0.1:4555)")
-	flag.StringVar(&c.MetricsAddr, "metrics-addr", c.MetricsAddr, "Prometheus metrics listen address (disabled when empty; e.g. 127.0.0.1:9090)")
+	flag.StringVar(&c.MetricsAddr, "metrics-port", c.MetricsAddr, "Prometheus metrics listen address or port (disabled when empty; e.g. 127.0.0.1:9090 or 9090)")
 	flag.StringVar(&c.ConfigFile, "config", c.ConfigFile, "worker config file path")
 	flag.StringVar(&c.LogDir, "log-dir", c.LogDir, "directory for worker log files")
 	flag.DurationVar(&c.DrainTimeout, "drain-timeout", c.DrainTimeout, "time to wait for in-flight jobs on shutdown (-1 to wait indefinitely, 0 to exit immediately)")

--- a/internal/mcp/metrics.go
+++ b/internal/mcp/metrics.go
@@ -1,0 +1,36 @@
+package mcp
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/gaspardpetit/llamapool/internal/logx"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// StartMetricsServer starts an HTTP server exposing Prometheus metrics on /metrics.
+// It returns the address it is listening on.
+func StartMetricsServer(ctx context.Context, addr string) (string, error) {
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+	srv := &http.Server{Handler: mux}
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return "", err
+	}
+	actual := ln.Addr().String()
+	go func() {
+		<-ctx.Done()
+		c, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(c)
+	}()
+	go func() {
+		if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
+			logx.Log.Error().Err(err).Str("addr", actual).Msg("metrics server error")
+		}
+	}()
+	return actual, nil
+}

--- a/internal/mcp/metrics_test.go
+++ b/internal/mcp/metrics_test.go
@@ -1,0 +1,26 @@
+package mcp
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"testing"
+)
+
+func TestStartMetricsServer(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	addr, err := StartMetricsServer(ctx, "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("start metrics server: %v", err)
+	}
+	resp, err := http.Get("http://" + addr + "/metrics")
+	if err != nil {
+		t.Fatalf("get metrics: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	if len(body) == 0 {
+		t.Fatal("empty response")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"fmt"
 	"net/http"
 	"time"
 
@@ -61,11 +62,7 @@ func New(reg *ctrl.Registry, metrics *ctrl.MetricsRegistry, sched ctrl.Scheduler
 	}
 	r.Handle("/api/workers/connect", ctrl.WSHandler(reg, metrics, cfg.ClientKey))
 
-	metricsPort := cfg.MetricsPort
-	if metricsPort == 0 {
-		metricsPort = cfg.Port
-	}
-	if metricsPort == cfg.Port {
+	if cfg.MetricsAddr == fmt.Sprintf(":%d", cfg.Port) {
 		r.Handle("/metrics", promhttp.Handler())
 	}
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -16,7 +16,7 @@ func TestMetricsEndpointDefaultPort(t *testing.T) {
 	reg := ctrl.NewRegistry()
 	metricsReg := ctrl.NewMetricsRegistry("test", "", "")
 	sched := &ctrl.LeastBusyScheduler{Reg: reg}
-	cfg := config.ServerConfig{Port: 8080, RequestTimeout: time.Second}
+	cfg := config.ServerConfig{Port: 8080, MetricsAddr: ":8080", RequestTimeout: time.Second}
 	h := New(reg, metricsReg, sched, mcp.NewRegistry(), cfg)
 	ts := httptest.NewServer(h)
 	defer ts.Close()
@@ -34,7 +34,7 @@ func TestMetricsEndpointSeparatePort(t *testing.T) {
 	reg := ctrl.NewRegistry()
 	metricsReg := ctrl.NewMetricsRegistry("test", "", "")
 	sched := &ctrl.LeastBusyScheduler{Reg: reg}
-	cfg := config.ServerConfig{Port: 8080, MetricsPort: 9090, RequestTimeout: time.Second}
+	cfg := config.ServerConfig{Port: 8080, MetricsAddr: ":9090", RequestTimeout: time.Second}
 	h := New(reg, metricsReg, sched, mcp.NewRegistry(), cfg)
 	ts := httptest.NewServer(h)
 	defer ts.Close()


### PR DESCRIPTION
## Summary
- unify metrics environment variable across server, worker, and mcp using `METRICS_PORT`
- allow server and worker metrics to bind to custom addresses
- add basic `/metrics` endpoint to `llamapool-mcp`

## Testing
- `go test ./internal/mcp -run TestStartMetricsServer -count=1`
- `go test ./internal/server -run TestMetricsEndpoint -count=1`
- `make lint` *(fails: Interrupt)*
- `make build` *(fails: Interrupt)*
- `make test` *(fails: Interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c8a78bac832c98fac5df21f7b4f8