### PR TITLE
Unify config file handling across tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Server-initiated JSON-RPC requests (for example sampling calls) are forwarded ac
 The new `llamapool-mcp` binary connects a private MCP provider to the public `llamapool-server`, allowing clients to invoke MCP methods via `POST /api/mcp/id/{id}`. The broker enforces request/response size limits, per-client concurrency caps, and 30s call timeouts; cancellation is not yet implemented. The client negotiates protocol versions and server capabilities, and exposes tunables such as `MCP_PROTOCOL_VERSION`, `MCP_HTTP_TIMEOUT`, and `MCP_MAX_INFLIGHT` for advanced deployments. By default `llamapool-mcp` requires absolute stdio commands and verifies TLS certificates; set `MCP_STDIO_ALLOW_RELATIVE=true` or `MCP_HTTP_INSECURE_SKIP_VERIFY=true` to relax these checks, and `MCP_OAUTH_TOKEN_FILE` to securely cache OAuth tokens on disk.
 By default the MCP relay exits if the server is unavailable. Add `-r` or `--reconnect` to keep retrying with backoff (1s×3, 5s×3, 15s×3, then every 30s). When enabled, it also probes the MCP provider and remains in a `not_ready` state until the provider becomes reachable.
 
-`llamapool-mcp` reads configuration from a YAML file when `MCP_CONFIG_FILE` is set. Values in the file—such as transport order, protocol version preference, or stdio working directory—are used as defaults and can be overridden by environment variables or CLI flags (e.g. `--mcp-http-url`, `--mcp-stdio-workdir`).
+`llamapool-mcp` reads configuration from a YAML file when `CONFIG_FILE` is set. Values in the file—such as transport order, protocol version preference, or stdio working directory—are used as defaults and can be overridden by environment variables or CLI flags (e.g. `--mcp-http-url`, `--mcp-stdio-workdir`).
 
 For transport configuration, common errors, and developer guidance see [doc/mcpclient.md](doc/mcpclient.md).
 For a comprehensive list of configuration options, see [doc/env.md](doc/env.md).
@@ -365,6 +365,7 @@ Commented example files are installed to `/etc/llamapool/`; edit these files to 
 When no explicit paths are provided, the worker falls back to OS defaults for
 its configuration and logs:
 
+- **Linux:** `/etc/llamapool/worker.yaml`
 - **macOS:** `~/Library/Application Support/llamapool/worker.yaml` and
   `~/Library/Logs/llamapool/`
 - **Windows:** `%ProgramData%\llamapool\worker.yaml` and

--- a/cmd/llamapool-server/main.go
+++ b/cmd/llamapool-server/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"net/http"
@@ -48,6 +49,12 @@ func main() {
 	if *showVersion {
 		fmt.Printf("llamapool-%s version=%s sha=%s date=%s\n", binaryName(), version, buildSHA, buildDate)
 		return
+	}
+
+	if cfg.ConfigFile != "" {
+		if err := cfg.LoadFile(cfg.ConfigFile); err != nil && !errors.Is(err, os.ErrNotExist) {
+			logx.Log.Fatal().Err(err).Str("path", cfg.ConfigFile).Msg("load config")
+		}
 	}
 
 	reg := ctrl.NewRegistry()

--- a/cmd/llamapool-worker/main.go
+++ b/cmd/llamapool-worker/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -42,6 +43,12 @@ func main() {
 	if *showVersion {
 		fmt.Printf("llamapool-%s version=%s sha=%s date=%s\n", binaryName(), version, buildSHA, buildDate)
 		return
+	}
+
+	if cfg.ConfigFile != "" {
+		if err := cfg.LoadFile(cfg.ConfigFile); err != nil && !errors.Is(err, os.ErrNotExist) {
+			logx.Log.Fatal().Err(err).Str("path", cfg.ConfigFile).Msg("load config")
+		}
 	}
 
 	worker.SetBuildInfo(version, buildSHA, buildDate)

--- a/doc/env.md
+++ b/doc/env.md
@@ -10,10 +10,15 @@ This document lists configuration options for the llamapool tools. Settings can 
 
 ## llamapool-server
 
-llamapool-server does not currently read from a configuration file; settings are provided via environment variables or CLI flags.
+The server optionally reads settings from a YAML config file. Defaults:
+
+- macOS: `~/Library/Application Support/llamapool/server.yaml`
+- Windows: `%ProgramData%\\llamapool\\server.yaml`
+- Linux: `/etc/llamapool/server.yaml`
 
 | Variable | Config key | Purpose | Default | CLI flag |
 |----------|------------|---------|---------|----------|
+| `CONFIG_FILE` | — | server config file path | OS-specific | `--config` |
 | `PORT` | — | HTTP listen port for the public API | `8080` | `--port` |
 | `METRICS_PORT` | — | Prometheus metrics listen port | same as `PORT` | `--metrics-port` |
 | `API_KEY` | — | client API key required for HTTP requests | unset (auth disabled) | `--api-key` |
@@ -33,11 +38,11 @@ The worker optionally reads settings from a YAML config file. Defaults:
 
 - macOS: `~/Library/Application Support/llamapool/worker.yaml`
 - Windows: `%ProgramData%\\llamapool\\worker.yaml`
-- Linux: none
+- Linux: `/etc/llamapool/worker.yaml`
 
 | Variable | Config key | Purpose | Default | CLI flag |
 |----------|------------|---------|---------|----------|
-| `CONFIG_FILE` | — | worker config file path | OS-specific (none on Linux) | `--config` |
+| `CONFIG_FILE` | — | worker config file path | OS-specific | `--config` |
 | `LOG_DIR` | — | directory for worker log files | OS-specific (none on Linux) | `--log-dir` |
 | `SERVER_URL` | `server_url` | server WebSocket URL for registration | `ws://localhost:8080/api/workers/connect` | `--server-url` |
 | `CLIENT_KEY` | `client_key` | shared secret for authenticating with the server | unset | `--client-key` |
@@ -57,7 +62,11 @@ Note: The YAML schema currently covers only a subset (`server_url`, `client_key`
 
 ## llamapool-mcp
 
-`llamapool-mcp` reads additional settings from a YAML file when `MCP_CONFIG_FILE` is set.
+`llamapool-mcp` reads additional settings from a YAML file when `CONFIG_FILE` is set. Defaults:
+
+- macOS: `~/Library/Application Support/llamapool/mcp.yaml`
+- Windows: `%ProgramData%\\llamapool\\mcp.yaml`
+- Linux: `/etc/llamapool/mcp.yaml`
 
 | Variable | Config key | Purpose | Default | CLI flag |
 |----------|------------|---------|---------|----------|
@@ -67,7 +76,7 @@ Note: The YAML schema currently covers only a subset (`server_url`, `client_key`
 | `PROVIDER_URL` | — | MCP provider URL | `http://127.0.0.1:7777/` | — |
 | `AUTH_TOKEN` | — | authorization token for broker requests | unset | — |
 | `CLIENT_KEY` | — | shared secret for authenticating with the server | unset | `--client-key` |
-| `MCP_CONFIG_FILE` | — | path to YAML config file | unset | `--mcp-config` |
+| `CONFIG_FILE` | — | path to YAML config file | OS-specific | `--config` |
 | `MCP_TRANSPORT_ORDER` | `order` | comma separated transport order | `stdio,http,oauth` | `--mcp-transport-order` |
 | `MCP_INIT_TIMEOUT` | `initTimeout` | timeout for transport startup | `5s` | `--mcp-init-timeout` |
 | `MCP_PROTOCOL_VERSION` | `protocolVersion` | preferred MCP protocol version | negotiated automatically | `--mcp-protocol-version` |
@@ -100,6 +109,5 @@ Note: The YAML schema currently covers only a subset (`server_url`, `client_key`
 | `OLLAMA_URL` | legacy alias for `OLLAMA_BASE_URL` | consolidate on `OLLAMA_BASE_URL` |
 | `METRICS_PORT` / `METRICS_ADDR` | inconsistent metrics naming | standardize on a single form (e.g., address) |
 | `BROKER_CALL_TIMEOUT_MS` vs `REQUEST_TIMEOUT` | mixed units and naming for timeouts | use duration strings consistently |
-| `CONFIG_FILE` / `MCP_CONFIG_FILE` | inconsistent config file naming | adopt a consistent `*_CONFIG_FILE` pattern |
 | worker YAML coverage | config file omits many settings (metrics, timeouts, names) | expand or deprecate partial config schema |
 

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -1,0 +1,33 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// DefaultConfigPath returns the default config file path for the given component
+// name (e.g. "worker.yaml", "server.yaml").
+func DefaultConfigPath(name string) string {
+	home, _ := os.UserHomeDir()
+	programData := os.Getenv("ProgramData")
+	return ResolveConfigPath(runtime.GOOS, home, programData, name)
+}
+
+// ResolveConfigPath constructs a config file path for the given OS and base
+// directories. It is mainly used in tests.
+func ResolveConfigPath(goos, home, programData, name string) string {
+	switch goos {
+	case "darwin":
+		return filepath.Join(home, "Library", "Application Support", "llamapool", name)
+	case "windows":
+		if programData == "" {
+			programData = "C:/ProgramData"
+		}
+		programData = strings.TrimRight(programData, "\\/")
+		return filepath.Join(programData, "llamapool", name)
+	default:
+		return filepath.Join("/etc", "llamapool", name)
+	}
+}

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -2,9 +2,12 @@ package config
 
 import (
 	"flag"
+	"os"
 	"strconv"
 	"strings"
 	"time"
+
+	"gopkg.in/yaml.v3"
 )
 
 // ServerConfig holds configuration for the llamapool server.
@@ -15,11 +18,15 @@ type ServerConfig struct {
 	ClientKey      string
 	RequestTimeout time.Duration
 	AllowedOrigins []string
+	ConfigFile     string
 }
 
 // BindFlags populates the struct with defaults from environment variables and
 // binds command line flags so main can call flag.Parse().
 func (c *ServerConfig) BindFlags() {
+	cfgPath := DefaultConfigPath("server.yaml")
+	c.ConfigFile = getEnv("CONFIG_FILE", cfgPath)
+
 	port, _ := strconv.Atoi(getEnv("PORT", "8080"))
 	c.Port = port
 	mp, _ := strconv.Atoi(getEnv("METRICS_PORT", strconv.Itoa(port)))
@@ -30,6 +37,7 @@ func (c *ServerConfig) BindFlags() {
 	c.RequestTimeout = rt
 	c.AllowedOrigins = splitComma(getEnv("ALLOWED_ORIGINS", strings.Join(c.AllowedOrigins, ",")))
 
+	flag.StringVar(&c.ConfigFile, "config", c.ConfigFile, "server config file path")
 	flag.IntVar(&c.Port, "port", c.Port, "HTTP listen port for the public API")
 	flag.IntVar(&c.MetricsPort, "metrics-port", c.MetricsPort, "Prometheus metrics listen port; defaults to the value of --port")
 	flag.StringVar(&c.APIKey, "api-key", c.APIKey, "client API key required for HTTP requests; leave empty to disable auth")
@@ -50,4 +58,13 @@ func splitComma(v string) []string {
 		parts[i] = strings.TrimSpace(p)
 	}
 	return parts
+}
+
+// LoadFile populates the config from a YAML file.
+func (c *ServerConfig) LoadFile(path string) error {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	return yaml.Unmarshal(b, c)
 }

--- a/internal/config/worker_test.go
+++ b/internal/config/worker_test.go
@@ -18,7 +18,7 @@ func TestResolveWorkerPaths(t *testing.T) {
 			name:       "linux",
 			goos:       "linux",
 			home:       "/home/user",
-			wantConfig: "",
+			wantConfig: "/etc/llamapool/worker.yaml",
 			wantLogDir: "",
 		},
 		{

--- a/internal/mcpclient/config.go
+++ b/internal/mcpclient/config.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gaspardpetit/llamapool/internal/config"
 	"github.com/mark3labs/mcp-go/client/transport"
 	"gopkg.in/yaml.v3"
 )
@@ -88,7 +89,8 @@ func (c *Config) BindFlags() {
 	if c.HTTP.Timeout == 0 {
 		c.HTTP.Timeout = 30 * time.Second
 	}
-	c.ConfigFile = getEnv("MCP_CONFIG_FILE", c.ConfigFile)
+	cfgPath := config.DefaultConfigPath("mcp.yaml")
+	c.ConfigFile = getEnv("CONFIG_FILE", cfgPath)
 	c.Order = splitComma(getEnv("MCP_TRANSPORT_ORDER", strings.Join(c.Order, ",")))
 	c.InitTimeout = parseDuration(getEnv("MCP_INIT_TIMEOUT", c.InitTimeout.String()))
 	c.ProtocolVersion = getEnv("MCP_PROTOCOL_VERSION", c.ProtocolVersion)
@@ -124,7 +126,7 @@ func (c *Config) BindFlags() {
 		c.EnableLegacySSE = getEnv("MCP_ENABLE_LEGACY_SSE", "") == "true"
 	}
 
-	flag.StringVar(&c.ConfigFile, "mcp-config", c.ConfigFile, "path to YAML config file")
+	flag.StringVar(&c.ConfigFile, "config", c.ConfigFile, "path to YAML config file")
 	flag.Func("mcp-transport-order", "comma separated transport order", func(v string) error { c.Order = splitComma(v); return nil })
 	flag.DurationVar(&c.InitTimeout, "mcp-init-timeout", c.InitTimeout, "timeout for transport startup and initialization")
 	flag.StringVar(&c.ProtocolVersion, "mcp-protocol-version", c.ProtocolVersion, "preferred MCP protocol version")


### PR DESCRIPTION
## Summary
- use a shared CONFIG_FILE across server, worker, and mcp
- add OS-specific default config paths and loader stubs for all binaries
- document new defaults and config file options

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a6ca5a8cd0832c8234743191a2886f