### PR TITLE
refine error logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,10 @@ requests to local Ollama instances. The repository contains two binaries:
 - `Warn` logs report expected failures (e.g., model not found, no worker available, worker busy, draining rejections).
 - `Error` logs report unexpected failures that require investigation (e.g., socket errors, serialization failures).
 - `Fatal` logs are reserved for unrecoverable errors that terminate the service.
+- Classify failures by impact:
+  - Business-case issues (e.g., invalid model requests) should log at **Warn**.
+  - Unexpected failures outside normal flow (e.g., backend timeouts or authentication rejections) should log at **Error**.
+  - Failures that will terminate or corrupt the service (e.g., OOM) should log at **Fatal**.
 
 ## Testing Guidelines
 - Unit tests live alongside the code using `*_test.go` files

--- a/cmd/llamapool-mcp/main.go
+++ b/cmd/llamapool-mcp/main.go
@@ -76,7 +76,11 @@ func monitorProvider(ctx context.Context, url string, shouldReconnect bool) {
 	for {
 		err := probeProvider(ctx, url)
 		if err != nil {
-			logx.Log.Warn().Err(err).Msg("mcp provider unavailable; not_ready")
+			lvl := logx.Log.Warn()
+			if strings.Contains(err.Error(), "status 401") || strings.Contains(err.Error(), "status 403") {
+				lvl = logx.Log.Error()
+			}
+			lvl.Err(err).Msg("mcp provider unavailable; not_ready")
 			if !shouldReconnect {
 				return
 			}

--- a/internal/api/chat_completions.go
+++ b/internal/api/chat_completions.go
@@ -147,6 +147,13 @@ func ChatCompletionsHandler(reg *ctrl.Registry, sched ctrl.Scheduler, metricsReg
 						w.Header().Set("Cache-Control", "no-store")
 					}
 					w.WriteHeader(m.Status)
+					if m.Status >= http.StatusBadRequest {
+						lvl := logx.Log.Warn()
+						if m.Status >= http.StatusInternalServerError || m.Status == http.StatusUnauthorized || m.Status == http.StatusForbidden {
+							lvl = logx.Log.Error()
+						}
+						lvl.Str("request_id", logID).Str("worker_id", worker.ID).Str("worker_name", worker.Name).Str("model", meta.Model).Int("status", m.Status).Msg("upstream response")
+					}
 					if flusher != nil {
 						flusher.Flush()
 					}
@@ -171,6 +178,7 @@ func ChatCompletionsHandler(reg *ctrl.Registry, sched ctrl.Scheduler, metricsReg
 							logx.Log.Error().Err(err).Msg("write upstream error")
 						}
 						errMsg = m.Error.Message
+						logx.Log.Error().Str("request_id", logID).Str("worker_id", worker.ID).Str("worker_name", worker.Name).Str("model", meta.Model).Str("error_code", m.Error.Code).Str("error", m.Error.Message).Msg("upstream error")
 					} else {
 						success = true
 					}

--- a/internal/worker/http_proxy.go
+++ b/internal/worker/http_proxy.go
@@ -75,6 +75,14 @@ func handleHTTPProxy(ctx context.Context, cfg config.WorkerConfig, sendCh chan [
 	b, _ := json.Marshal(hmsg)
 	sendMsg(reqCtx, sendCh, b)
 
+	if resp.StatusCode >= http.StatusBadRequest {
+		lvl := logx.Log.Warn()
+		if resp.StatusCode >= http.StatusInternalServerError || resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+			lvl = logx.Log.Error()
+		}
+		lvl.Str("request_id", req.RequestID).Int("status", resp.StatusCode).Msg("proxy response")
+	}
+
 	buf := make([]byte, 32*1024)
 	for {
 		n, err := resp.Body.Read(buf)


### PR DESCRIPTION
## Summary
- document logging severity guidelines for business, unexpected, and fatal errors
- log upstream HTTP errors in worker and surface them through server handlers
- classify MCP provider authentication failures as errors

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a7407acaa4832c9cdbcafbf7c57931