### PR TITLE
feat: add global drain support

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,8 @@ progress, the worker exits immediately; otherwise it waits up to
 Send `SIGTERM` again to terminate immediately. Set `--drain-timeout=0` to exit
 without waiting or `--drain-timeout=-1` to wait indefinitely.
 
+The server and MCP relay also honor `DRAIN_TIMEOUT` (via env or `--drain-timeout`) to finish in-flight requests before shutting down. The server defaults to 5m while the MCP relay uses 1m.
+
 The worker polls the local Ollama instance (default every 1m) so that
 `connected_to_backend` and `models` stay current in the `/status` output.
 If the model list changes, the worker proactively notifies the server so

--- a/doc/env.md
+++ b/doc/env.md
@@ -31,6 +31,7 @@ The server optionally reads settings from a YAML config file. Defaults:
 | `BROKER_WS_HEARTBEAT_MS` | — | MCP WebSocket heartbeat interval in milliseconds | `15000` | — |
 | `BROKER_WS_DEAD_AFTER_MS` | — | MCP WebSocket idle timeout in milliseconds | `45000` | — |
 | `BROKER_MAX_CONCURRENCY_PER_CLIENT` | — | maximum concurrent MCP sessions per client | `16` | — |
+| `DRAIN_TIMEOUT` | — | time to wait for in-flight requests on shutdown | `5m` | `--drain-timeout` |
 
 ## llamapool-worker
 
@@ -98,6 +99,7 @@ Note: The YAML schema currently covers only a subset (`server_url`, `client_key`
 | `MCP_OAUTH_SCOPES` | `oauth.scopes` | OAuth scopes | unset | `--mcp-oauth-scopes` |
 | `MCP_OAUTH_TOKEN_FILE` | `oauth.tokenFile` | path to OAuth token cache file | unset | `--mcp-oauth-token-file` |
 | `MCP_ENABLE_LEGACY_SSE` | `enableLegacySSE` | enable legacy SSE transport | `false` | `--mcp-enable-legacy-sse` |
+| `DRAIN_TIMEOUT` | — | time to wait for in-flight calls on shutdown | `1m` | `--drain-timeout` |
 
 ### Consistency notes
 

--- a/doc/server-endpoints.md
+++ b/doc/server-endpoints.md
@@ -19,6 +19,8 @@ Endpoints are grouped by functional area.
 | `GET /api/state` | – | Server state snapshot (JSON). | API key |
 | `GET /api/state/stream` | – | Server state stream (SSE). | API key |
 
+The JSON snapshot includes a top-level `state` field reporting `ready`, `not_ready`, or `draining`.
+
 ## Inference API
 
 ### Worker Registration

--- a/internal/api/state_test.go
+++ b/internal/api/state_test.go
@@ -34,6 +34,9 @@ func TestGetState(t *testing.T) {
 	if resp.Workers[0].Name != "w1" {
 		t.Fatalf("expected worker name")
 	}
+	if resp.State != "ready" {
+		t.Fatalf("expected ready state, got %s", resp.State)
+	}
 }
 
 func TestGetStateStream(t *testing.T) {

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -20,6 +20,7 @@ type ServerConfig struct {
 	RequestTimeout time.Duration
 	AllowedOrigins []string
 	ConfigFile     string
+	DrainTimeout   time.Duration
 }
 
 // BindFlags populates the struct with defaults from environment variables and
@@ -42,6 +43,11 @@ func (c *ServerConfig) BindFlags() {
 	c.ClientKey = getEnv("CLIENT_KEY", "")
 	rt, _ := time.ParseDuration(getEnv("REQUEST_TIMEOUT", "60s"))
 	c.RequestTimeout = rt
+	if d, err := time.ParseDuration(getEnv("DRAIN_TIMEOUT", "5m")); err == nil {
+		c.DrainTimeout = d
+	} else {
+		c.DrainTimeout = 5 * time.Minute
+	}
 	c.AllowedOrigins = splitComma(getEnv("ALLOWED_ORIGINS", strings.Join(c.AllowedOrigins, ",")))
 
 	flag.StringVar(&c.ConfigFile, "config", c.ConfigFile, "server config file path")
@@ -50,6 +56,7 @@ func (c *ServerConfig) BindFlags() {
 	flag.StringVar(&c.APIKey, "api-key", c.APIKey, "client API key required for HTTP requests; leave empty to disable auth")
 	flag.StringVar(&c.ClientKey, "client-key", c.ClientKey, "shared key clients must present when registering")
 	flag.DurationVar(&c.RequestTimeout, "request-timeout", c.RequestTimeout, "maximum duration to process a client request")
+	flag.DurationVar(&c.DrainTimeout, "drain-timeout", c.DrainTimeout, "time to wait for in-flight requests on shutdown")
 	flag.Func("allowed-origins", "comma separated list of allowed CORS origins", func(v string) error {
 		c.AllowedOrigins = splitComma(v)
 		return nil

--- a/internal/ctrl/metrics.go
+++ b/internal/ctrl/metrics.go
@@ -103,6 +103,7 @@ type MCPState struct {
 
 // StateResponse is the top-level snapshot returned to clients.
 type StateResponse struct {
+	State          string           `json:"state"`
 	Server         ServerSnapshot   `json:"server"`
 	WorkersSummary WorkersSummary   `json:"workers_summary"`
 	Models         []ModelCount     `json:"models"`
@@ -125,6 +126,13 @@ type MetricsRegistry struct {
 	schedulerQueueLen  int
 
 	workers map[string]*workerMetrics
+}
+
+// JobsInflight returns the number of jobs currently in flight.
+func (m *MetricsRegistry) JobsInflight() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.jobsInflight
 }
 
 type workerMetrics struct {

--- a/internal/drain/drain.go
+++ b/internal/drain/drain.go
@@ -1,0 +1,14 @@
+package drain
+
+import "sync/atomic"
+
+var draining atomic.Bool
+
+// Start marks the process as draining.
+func Start() { draining.Store(true) }
+
+// Stop clears the draining flag.
+func Stop() { draining.Store(false) }
+
+// IsDraining reports whether draining is in progress.
+func IsDraining() bool { return draining.Load() }


### PR DESCRIPTION
## Summary
- add shared drain flag and DRAIN_TIMEOUT to server and MCP relay
- expose server readiness and draining state via `/api/state`
- block new work during server drain

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a74cb9deec832c8271d1030416764e