### PR TITLE
Track worker token usage and rates

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,8 @@ curl http://localhost:8080/metrics
 curl http://localhost:9090/metrics
 ```
 
+The HTML dashboard at `/state` visualizes workers and reports per-worker token totals and average token processing rates.
+
 The server also exposes OpenAI-style model listing endpoints:
 
 ```bash
@@ -483,7 +485,7 @@ For manual end-to-end verification on a clean VM, see [desktop/windows/ACCEPTANC
 | Prometheus metrics endpoint | ✅ | `/metrics`; includes build info, per-model counters, histograms; supports `METRICS_PORT`/`--metrics-port` |
 | Real-time state API (JSON) | ✅ | `GET /api/state` returns full server/worker snapshot |
 | Real-time state stream (SSE) | ✅ | `GET /api/state/stream` for dashboards |
-| Token usage tracking | ✅ | Per-model and per-worker token totals (in/out) |
+| Token usage tracking | ✅ | Per-model and per-worker token totals (in/out) with average rate on dashboard |
 | Per-model success/error rates | ✅ | `llamapool_model_requests_total{outcome=...}` |
 | Build info (server & worker) | ✅ | Server ldflags; worker-reported version/SHA/date reflected in state |
 | Draining | ✅ | Workers can be configured to drain before exiting to avoid interrupting an ongoing request with `--drain-timeout` |

--- a/internal/api/chat_completions.go
+++ b/internal/api/chat_completions.go
@@ -106,13 +106,25 @@ func ChatCompletionsHandler(reg *ctrl.Registry, sched ctrl.Scheduler, metricsReg
 		bytesSent := false
 		success := false
 		var errMsg string
+		var tokensIn, tokensOut uint64
+		var sseBuf string
+		var bodyBuf []byte
 
 		defer func() {
 			dur := time.Since(start)
-			metricsReg.RecordJobEnd(worker.ID, meta.Model, dur, 0, 0, success, errMsg)
+			metricsReg.RecordJobEnd(worker.ID, meta.Model, dur, tokensIn, tokensOut, success, errMsg)
 			metricsReg.SetWorkerStatus(worker.ID, ctrl.StatusIdle)
 			metrics.ObserveRequestDuration(worker.ID, meta.Model, dur)
+			metrics.RecordWorkerProcessingTime(worker.ID, dur)
 			metrics.RecordModelRequest(meta.Model, success)
+			if tokensIn > 0 {
+				metrics.RecordModelTokens(meta.Model, "in", tokensIn)
+				metrics.RecordWorkerTokens(worker.ID, "in", tokensIn)
+			}
+			if tokensOut > 0 {
+				metrics.RecordModelTokens(meta.Model, "out", tokensOut)
+				metrics.RecordWorkerTokens(worker.ID, "out", tokensOut)
+			}
 		}()
 		for {
 			select {
@@ -168,7 +180,56 @@ func ChatCompletionsHandler(reg *ctrl.Registry, sched ctrl.Scheduler, metricsReg
 							}
 						}
 					}
+					if meta.Stream {
+						sseBuf += string(m.Data)
+						for {
+							idx := strings.Index(sseBuf, "\n")
+							if idx == -1 {
+								break
+							}
+							line := strings.TrimRight(sseBuf[:idx], "\r")
+							sseBuf = sseBuf[idx+1:]
+							if !strings.HasPrefix(line, "data:") {
+								continue
+							}
+							payload := strings.TrimSpace(line[5:])
+							if payload == "" || payload == "[DONE]" {
+								continue
+							}
+							var v struct {
+								Usage struct {
+									PromptTokens     uint64 `json:"prompt_tokens"`
+									CompletionTokens uint64 `json:"completion_tokens"`
+								} `json:"usage"`
+							}
+							if err := json.Unmarshal([]byte(payload), &v); err == nil {
+								if v.Usage.PromptTokens > 0 {
+									tokensIn = v.Usage.PromptTokens
+								}
+								if v.Usage.CompletionTokens > 0 {
+									tokensOut = v.Usage.CompletionTokens
+								}
+							}
+						}
+					} else {
+						bodyBuf = append(bodyBuf, m.Data...)
+					}
 				case ctrl.HTTPProxyResponseEndMessage:
+					if !meta.Stream {
+						var v struct {
+							Usage struct {
+								PromptTokens     uint64 `json:"prompt_tokens"`
+								CompletionTokens uint64 `json:"completion_tokens"`
+							} `json:"usage"`
+						}
+						_ = json.Unmarshal(bodyBuf, &v)
+						if v.Usage.PromptTokens > 0 {
+							tokensIn = v.Usage.PromptTokens
+						}
+						if v.Usage.CompletionTokens > 0 {
+							tokensOut = v.Usage.CompletionTokens
+						}
+					}
 					if m.Error != nil && !bytesSent {
 						if !headersSent {
 							w.Header().Set("Content-Type", "application/json")

--- a/internal/api/chat_completions_test.go
+++ b/internal/api/chat_completions_test.go
@@ -23,6 +23,8 @@ func TestChatCompletionsHeaders(t *testing.T) {
 	wk := &ctrl.Worker{ID: "w1", Models: map[string]bool{"m": true}, MaxConcurrency: 1, Send: make(chan interface{}, 1), Jobs: make(map[string]chan interface{})}
 	reg.Add(wk)
 	metricsReg := ctrl.NewMetricsRegistry("", "", "")
+	metricsReg.UpsertWorker("w1", "w1", "", "", "", 1, []string{"m"})
+	metricsReg.SetWorkerStatus("w1", ctrl.StatusConnected)
 	h := ChatCompletionsHandler(reg, sched, metricsReg)
 
 	go func() {

--- a/internal/ctrl/metrics.go
+++ b/internal/ctrl/metrics.go
@@ -46,6 +46,8 @@ type WorkerSnapshot struct {
 	LastError         string                   `json:"last_error,omitempty"`
 	TokensInTotal     uint64                   `json:"tokens_in_total"`
 	TokensOutTotal    uint64                   `json:"tokens_out_total"`
+	TokensTotal       uint64                   `json:"tokens_total"`
+	AvgTokensPerSec   float64                  `json:"avg_tokens_per_second"`
 	PerModel          map[string]PerModelStats `json:"per_model"`
 }
 
@@ -362,6 +364,11 @@ func (m *MetricsRegistry) Snapshot() StateResponse {
 		if w.processedTotal > 0 {
 			avg = float64(w.processingMsTotal) / float64(w.processedTotal)
 		}
+		tokensTotal := w.tokensInTotal + w.tokensOutTotal
+		rate := 0.0
+		if w.processingMsTotal > 0 {
+			rate = float64(tokensTotal) / (float64(w.processingMsTotal) / 1000)
+		}
 		perModel := make(map[string]PerModelStats, len(w.perModel))
 		for k, v := range w.perModel {
 			perModel[k] = *v
@@ -386,6 +393,8 @@ func (m *MetricsRegistry) Snapshot() StateResponse {
 			LastError:         w.lastError,
 			TokensInTotal:     w.tokensInTotal,
 			TokensOutTotal:    w.tokensOutTotal,
+			TokensTotal:       tokensTotal,
+			AvgTokensPerSec:   rate,
 			PerModel:          perModel,
 		}
 		resp.Workers = append(resp.Workers, snapshot)

--- a/internal/metrics/prom_test.go
+++ b/internal/metrics/prom_test.go
@@ -15,12 +15,20 @@ func TestPromMetrics(t *testing.T) {
 	RecordModelRequest("llama3:8b", true)
 	RecordModelTokens("llama3:8b", "in", 10)
 	ObserveRequestDuration("w1", "llama3:8b", 100*time.Millisecond)
+	RecordWorkerTokens("w1", "in", 10)
+	RecordWorkerProcessingTime("w1", 100*time.Millisecond)
 
 	if v := testutil.ToFloat64(modelRequests.WithLabelValues("llama3:8b", "success")); v != 1 {
 		t.Fatalf("model requests: %v", v)
 	}
 	if v := testutil.ToFloat64(modelTokens.WithLabelValues("in", "llama3:8b")); v != 10 {
 		t.Fatalf("model tokens: %v", v)
+	}
+	if v := testutil.ToFloat64(workerTokens.WithLabelValues("w1", "in")); v != 10 {
+		t.Fatalf("worker tokens: %v", v)
+	}
+	if v := testutil.ToFloat64(workerProcessing.WithLabelValues("w1")); v != 0.1 {
+		t.Fatalf("worker processing: %v", v)
 	}
 	if v := testutil.ToFloat64(buildInfo.WithLabelValues("2024-01-01", "abc", "1.0.0")); v != 1 {
 		t.Fatalf("build info: %v", v)

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -66,12 +66,15 @@ func RelayGenerateStream(ctx context.Context, reg *ctrl.Registry, metricsReg *ct
 		metricsReg.RecordJobEnd(worker.ID, req.Model, dur, tokensIn, tokensOut, success, errMsg)
 		metricsReg.SetWorkerStatus(worker.ID, ctrl.StatusIdle)
 		metrics.ObserveRequestDuration(worker.ID, req.Model, dur)
+		metrics.RecordWorkerProcessingTime(worker.ID, dur)
 		metrics.RecordModelRequest(req.Model, success)
 		if tokensIn > 0 {
 			metrics.RecordModelTokens(req.Model, "in", tokensIn)
+			metrics.RecordWorkerTokens(worker.ID, "in", tokensIn)
 		}
 		if tokensOut > 0 {
 			metrics.RecordModelTokens(req.Model, "out", tokensOut)
+			metrics.RecordWorkerTokens(worker.ID, "out", tokensOut)
 		}
 	}()
 
@@ -194,12 +197,15 @@ func RelayGenerateOnce(ctx context.Context, reg *ctrl.Registry, metricsReg *ctrl
 		metricsReg.RecordJobEnd(worker.ID, req.Model, dur, tokensIn, tokensOut, success, errMsg)
 		metricsReg.SetWorkerStatus(worker.ID, ctrl.StatusIdle)
 		metrics.ObserveRequestDuration(worker.ID, req.Model, dur)
+		metrics.RecordWorkerProcessingTime(worker.ID, dur)
 		metrics.RecordModelRequest(req.Model, success)
 		if tokensIn > 0 {
 			metrics.RecordModelTokens(req.Model, "in", tokensIn)
+			metrics.RecordWorkerTokens(worker.ID, "in", tokensIn)
 		}
 		if tokensOut > 0 {
 			metrics.RecordModelTokens(req.Model, "out", tokensOut)
+			metrics.RecordWorkerTokens(worker.ID, "out", tokensOut)
 		}
 	}()
 

--- a/internal/server/state.html
+++ b/internal/server/state.html
@@ -132,6 +132,9 @@ function render() {
       <div class="name"><span class="status-dot" style="background:${status}"></span>${w.name || w.id}</div>
       <div>${w.status}</div>
       <div>inflight: ${w.inflight}</div>
+      <div>tokens in/out: ${w.tokens_in_total}/${w.tokens_out_total}</div>
+      <div>total tokens: ${w.tokens_total}</div>
+      <div>avg rate: ${w.avg_tokens_per_second.toFixed(2)} tok/s</div>
     `;
     container.appendChild(div);
   });


### PR DESCRIPTION
## Summary
- parse usage metadata from chat completions responses to track prompt and completion tokens per worker
- expose worker token and processing time metrics in Prometheus and state snapshots
- display per-worker token totals and average rate on the `/state` dashboard and document the new metrics

## Testing
- `make lint`
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a74edb771c832caba69f8f27dfa65d